### PR TITLE
Fix alias resolution for tests

### DIFF
--- a/packages/common/vitest.config.ts
+++ b/packages/common/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@dome/common': path.resolve(__dirname, './src'),
+    },
+  },
   test: {
     environment: 'node',
     include: ['**/*.test.ts', '**/*.test.js'],

--- a/services/chat/vitest.config.ts
+++ b/services/chat/vitest.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
   test: {
     environment: 'node',
     globals: true,
     setupFiles: ['./tests/setup.ts'],
+    alias: {
+      '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
+    },
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],


### PR DESCRIPTION
## Summary
- alias `@dome/common` to local source in `packages/common`
- alias `@dome/common` in Chat service tests

## Testing
- `just build`
- `just lint`
- `just test`
