### PR TITLE
Fix randomUUID usage

### DIFF
--- a/packages/common/src/middleware/requestContext.ts
+++ b/packages/common/src/middleware/requestContext.ts
@@ -1,4 +1,5 @@
 import type { Context, Next } from 'hono';
+import crypto from 'node:crypto';
 
 /**
  * Middleware factory for creating request context middleware
@@ -10,7 +11,10 @@ export function createRequestContextMiddleware(
 ): (c: Context, next: Next) => Promise<void> {
   return async (c: Context, next: Next): Promise<void> => {
     // Get the request ID from the header or generate a new one
-    const requestId = c.req.header(requestIdHeader) || c.get('requestId') || crypto.randomUUID();
+    const requestId =
+      c.req.header(requestIdHeader) ||
+      c.get('requestId') ||
+      crypto.randomUUID();
 
     // Set the request ID in the context for backward compatibility
     c.set('requestId', requestId);

--- a/packages/common/src/types/events.ts
+++ b/packages/common/src/types/events.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import crypto from 'node:crypto';
 
 /**
  * Base event schema that all events must extend
@@ -80,7 +81,9 @@ export type Event = z.infer<typeof EventSchema>;
 /**
  * Event factory functions
  */
-export const createReminderDueEvent = (data: ReminderDueEvent['data']): ReminderDueEvent => ({
+export const createReminderDueEvent = (
+  data: ReminderDueEvent['data'],
+): ReminderDueEvent => ({
   id: crypto.randomUUID(),
   timestamp: new Date().toISOString(),
   type: 'reminder_due',

--- a/packages/common/tests/requestContext.test.ts
+++ b/packages/common/tests/requestContext.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import crypto from 'node:crypto';
 import { createRequestContextMiddleware } from '../src/middleware/requestContext';
 
 describe('createRequestContextMiddleware', () => {
@@ -19,7 +20,7 @@ describe('createRequestContextMiddleware', () => {
 
   it('generates id when none provided', async () => {
     const uuid = 'generated';
-    vi.spyOn(global.crypto, 'randomUUID').mockReturnValue(uuid as any);
+    vi.spyOn(crypto, 'randomUUID').mockReturnValue(uuid as any);
     const c: any = {
       req: { header: vi.fn().mockReturnValue(undefined) },
       get: vi.fn().mockReturnValue(undefined),


### PR DESCRIPTION
## Summary
- import `node:crypto` for uuid generation
- spy on crypto.randomUUID in middleware tests
- ensure Node 18 compatibility

## Testing
- `just lint`
- `just build`
- `just test`
- `just test-pkg common`