### PR TITLE
Add ai-processor unit tests

### DIFF
--- a/services/ai-processor/tests/llmService.test.ts
+++ b/services/ai-processor/tests/llmService.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import { LlmService } from '../src/services/llmService';
+import { BaseContentSchema } from '../src/schemas';
+
+const env: any = { AI: { run: async () => ({ response: '{}' }) } };
+
+// Helper to access private method
+function parse(service: LlmService, response: string) {
+  return (service as any).parseStructuredResponse(response, BaseContentSchema, 'req');
+}
+
+describe('LlmService.parseStructuredResponse', () => {
+  it('parses valid JSON inside code fence', () => {
+    const service = new LlmService(env);
+    const res = parse(service, '```json\n{"title":"t","summary":"s"}\n```');
+    expect(res.title).toBe('t');
+    expect(res.summary).toBe('s');
+  });
+
+  it('throws truncated error for incomplete JSON', () => {
+    const service = new LlmService(env);
+    const input = '{"title":"t"';
+    expect(() => parse(service, input)).toThrowError('suspected truncation');
+  });
+
+  it('throws generic error for invalid JSON', () => {
+    const service = new LlmService(env);
+    expect(() => parse(service, 'not json')).toThrowError('Failed to parse structured response');
+  });
+});

--- a/services/ai-processor/tests/processor.test.ts
+++ b/services/ai-processor/tests/processor.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { ContentProcessor } from '../src/utils/processor';
+import type { ProcessorServices } from '../src/utils/processor';
+
+const env: any = {};
+const services: ProcessorServices = {
+  llm: { processContent: async () => ({ title: 't' }) } as any,
+  silo: {} as any,
+};
+
+describe('ContentProcessor.normalize', () => {
+  it('fills defaults when fields missing', () => {
+    const cp = new ContentProcessor(env, services);
+    const result = (cp as any).normalize({ title: 'Hello' } as any);
+    expect(result.title).toBe('Hello');
+    expect(result.processingVersion).toBe(2);
+    expect(result.modelUsed).toBe('@cf/google/gemma-7b-it-lora');
+    expect(result.summary).toBeUndefined();
+  });
+});

--- a/services/ai-processor/tests/todos.test.ts
+++ b/services/ai-processor/tests/todos.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi } from 'vitest';
+import { sendTodosToQueue } from '../src/todos';
+import { PUBLIC_USER_ID } from '@dome/common';
+
+const makeQueue = () => ({ send: vi.fn() });
+
+const baseContent = {
+  id: '1',
+  userId: 'u1',
+  category: 'note',
+  mimeType: 'text/plain',
+  metadata: {
+    todos: [{ text: 'a' }],
+    processingVersion: 1,
+    modelUsed: 'm',
+    title: 't',
+  },
+  timestamp: Date.now(),
+};
+
+describe('sendTodosToQueue', () => {
+  it('sends todos when userId present', async () => {
+    const q = makeQueue();
+    await sendTodosToQueue(baseContent as any, q as any);
+    expect(q.send).toHaveBeenCalledTimes(1);
+    expect(q.send.mock.calls[0][0]).toMatchObject({ userId: 'u1', description: 'a' });
+  });
+
+  it('skips when no userId', async () => {
+    const q = makeQueue();
+    await sendTodosToQueue({ ...baseContent, userId: null } as any, q as any);
+    expect(q.send).not.toHaveBeenCalled();
+  });
+
+  it('skips public user', async () => {
+    const q = makeQueue();
+    await sendTodosToQueue({ ...baseContent, userId: PUBLIC_USER_ID } as any, q as any);
+    expect(q.send).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for `LlmService.parseStructuredResponse`
- test `ContentProcessor.normalize` defaults
- verify `sendTodosToQueue` behaviour

## Testing
- `just lint`
- `just build`
- `just test`
