### PR TITLE
Modernize home and docs landing pages

### DIFF
--- a/fern/docs/pages/welcome.mdx
+++ b/fern/docs/pages/welcome.mdx
@@ -1,17 +1,15 @@
 ---
-title: Welcome to the Dome API Documentation
-subtitle: Your guide to the AI-Powered Exobrain API
+title: Welcome
+subtitle: Modern Dome API
 slug: welcome
-description: Discover how to integrate with the Dome API to leverage its powerful exobrain capabilities, manage data, and interact with AI-driven services.
+description: Quickly integrate with the Dome API and build intelligent assistants.
 ---
 
-Welcome to the Dome API documentation! This site provides comprehensive information and resources to help you get started with our API.
-
-The Dome API is an AI-Powered Exobrain service designed to help you manage and interact with your data in intelligent ways. Whether you're looking to integrate chat functionalities, manage notes, or perform advanced searches, our API provides the tools you need.
+Welcome to the Dome API documentation. Here you'll find everything you need to get started quickly.
 
 ## Getting Started
 
-This documentation will guide you through the core concepts, authentication, and available endpoints of the Dome API.
+The following sections cover the basics of authentication and core concepts.
 
 <CardGroup>
   <Card title="API Reference" icon="fa-solid fa-code" href="/api-reference" />
@@ -19,14 +17,12 @@ This documentation will guide you through the core concepts, authentication, and
   <Card title="Chat & WebSocket" icon="fa-solid fa-comments" href="/chat-websocket" />
 </CardGroup>
 
-## Key Features
+## Highlights
 
-- **AI-Powered Chat**: Engage with a sophisticated chat system capable of understanding context and providing intelligent responses.
-- **Note Management**: Store, retrieve, and manage your notes efficiently.
-- **Advanced Search**: Perform powerful searches across your data.
-- **Content Ingestion**: Seamlessly ingest content from various sources (e.g., Notion).
-- **Secure Authentication**: Robust authentication mechanisms to protect your data.
+- **AI chat streaming**
+- **Note and content management**
+- **Powerful search**
 
-## Get support
+## Need help?
 
-If you encounter any issues or have questions, please refer to the relevant sections of this documentation. For bugs or feature requests, you can open an issue on our project's GitHub repository (link to be added) or reach out to the development team.
+Open an issue on GitHub or reach out to the team.

--- a/ui/src/app/page.tsx
+++ b/ui/src/app/page.tsx
@@ -9,43 +9,32 @@ export default function HomePage() {
   const { user, isLoading } = useAuth();
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-[calc(100vh-4rem)] p-4 text-center">
-      <main className="flex flex-1 flex-col items-center justify-center gap-6">
-        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">
-          Welcome to Dome Knowledge Base
-        </h1>
-        <p className="max-w-xl text-lg text-muted-foreground sm:text-xl">
-          This is the central hub for all information. Explore features like chat, search, and
-          personalized settings.
+    <div className="flex min-h-[calc(100vh-4rem)] flex-col">
+      <section className="flex flex-1 flex-col items-center justify-center bg-gradient-to-br from-primary/10 to-secondary/10 px-4 text-center">
+        <h1 className="mb-4 text-5xl font-bold sm:text-6xl">Dome Knowledge Base</h1>
+        <p className="max-w-xl text-lg text-muted-foreground">
+          Your modern personal exobrain powered by AI.
         </p>
-        <div className="mt-8 grid gap-6 sm:grid-cols-3">
+        <div className="mt-10 grid gap-6 sm:grid-cols-3">
           <div className="flex flex-col items-center gap-2">
             <MessageSquare className="h-8 w-8 text-primary" />
             <h3 className="text-lg font-semibold">Chat with your knowledge</h3>
-            <p className="text-sm text-muted-foreground">
-              Ask questions and get answers from your personal data.
-            </p>
+            <p className="text-sm text-muted-foreground">Ask questions and get answers from your data.</p>
           </div>
           <div className="flex flex-col items-center gap-2">
             <Search className="h-8 w-8 text-primary" />
             <h3 className="text-lg font-semibold">Powerful search</h3>
-            <p className="text-sm text-muted-foreground">
-              Quickly find notes and files across all your sources.
-            </p>
+            <p className="text-sm text-muted-foreground">Find notes and files instantly.</p>
           </div>
           <div className="flex flex-col items-center gap-2">
             <Plug className="h-8 w-8 text-primary" />
             <h3 className="text-lg font-semibold">Easy integrations</h3>
-            <p className="text-sm text-muted-foreground">
-              Connect services like GitHub or Notion in seconds.
-            </p>
+            <p className="text-sm text-muted-foreground">Connect services like GitHub or Notion.</p>
           </div>
         </div>
-        <div className="flex flex-col sm:flex-row gap-4 mt-6">
+        <div className="mt-8 flex flex-col gap-4 sm:flex-row">
           {isLoading ? (
-            <Button disabled size="lg">
-              Loading...
-            </Button>
+            <Button disabled size="lg">Loading...</Button>
           ) : user ? (
             <Link href="/chat">
               <Button size="lg" className="group">
@@ -57,8 +46,7 @@ export default function HomePage() {
             <>
               <Link href="/login">
                 <Button size="lg" variant="outline" className="group">
-                  <LogIn className="mr-2 h-5 w-5" />
-                  Login
+                  <LogIn className="mr-2 h-5 w-5" /> Login
                 </Button>
               </Link>
               <Link href="/register">
@@ -70,9 +58,9 @@ export default function HomePage() {
             </>
           )}
         </div>
-      </main>
-      <footer className="py-8 text-sm text-muted-foreground">
-        © {new Date().getFullYear()} Dome Knowledge Base. All rights reserved.
+      </section>
+      <footer className="py-8 text-center text-sm text-muted-foreground">
+        © {new Date().getFullYear()} Dome Knowledge Base.
       </footer>
     </div>
   );


### PR DESCRIPTION
## Summary
- restyle the Next.js home page with a gradient hero section
- simplify the documentation welcome page content

## Testing
- `pnpm install`
- `just lint`
- `just build`
- `just test`
