### PR TITLE
Add robust queue helper tests

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -69,6 +69,14 @@ The package provides common types used across services:
 - `ServiceInfo`: Service information format
 - `ExtendedError`: Extended error interface
 
+### Queue Message Utilities
+
+Helpers for validating and converting queue messages between services:
+
+- `serializeQueueMessage(schema, message)`: validate and stringify a message.
+- `parseQueueMessage(schema, body)`: parse and validate a JSON message body.
+- `parseMessageBatch(schema, batch)`: convert a batch of raw messages into typed objects.
+
 ## Migration Guide
 
 When migrating from service-specific implementations to the common package:

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -24,3 +24,6 @@ export * from './constants/publicContent.js';
 
 // Export AI config system
 export * from './ai/index.js';
+
+// Queue helpers
+export * from './queue/index.js';

--- a/packages/common/src/queue/index.ts
+++ b/packages/common/src/queue/index.ts
@@ -1,0 +1,81 @@
+import { z, ZodSchema } from 'zod';
+import { MessageProcessingError } from '../errors/ServiceError.js';
+
+/** Raw message format coming from Cloudflare Queues */
+export interface RawQueueMessage {
+  id: string;
+  timestamp: number;
+  body: string;
+}
+
+/** Parsed message after validation */
+export interface ParsedQueueMessage<T> {
+  id: string;
+  timestamp: number;
+  body: T;
+}
+
+/** Raw batch format coming from Cloudflare */
+export interface RawMessageBatch {
+  queue: string;
+  messages: RawQueueMessage[];
+}
+
+/** Parsed batch with typed messages */
+export interface ParsedMessageBatch<T> {
+  queue: string;
+  messages: ParsedQueueMessage<T>[];
+}
+
+/**
+ * Serialize a queue message using the provided schema.
+ * @param schema Zod schema describing the message shape
+ * @param message Message payload to validate and serialize
+ * @throws MessageProcessingError if validation fails
+ */
+export function serializeQueueMessage<T>(schema: ZodSchema<T>, message: T): string {
+  try {
+    const data = schema.parse(message);
+    return JSON.stringify(data);
+  } catch (err) {
+    if (err instanceof z.ZodError) {
+      throw new MessageProcessingError('Queue message validation failed', { issues: err.format() });
+    }
+    throw err;
+  }
+}
+
+/**
+ * Parse a queue message body using the given schema.
+ * @param schema Zod schema describing the message shape
+ * @param body Raw JSON string from the queue
+ * @returns Parsed and validated message
+ * @throws MessageProcessingError when parsing or validation fails
+ */
+export function parseQueueMessage<T>(schema: ZodSchema<T>, body: string): T {
+  try {
+    const parsed = JSON.parse(body);
+    return schema.parse(parsed);
+  } catch (err) {
+    if (err instanceof SyntaxError) {
+      throw new MessageProcessingError('Invalid JSON in queue message');
+    }
+    if (err instanceof z.ZodError) {
+      throw new MessageProcessingError('Queue message validation failed', { issues: err.format() });
+    }
+    throw err;
+  }
+}
+
+/**
+ * Convert a raw message batch from Cloudflare to a typed batch.
+ * Messages that fail validation will throw a MessageProcessingError.
+ */
+export function parseMessageBatch<T>(schema: ZodSchema<T>, batch: RawMessageBatch): ParsedMessageBatch<T> {
+  const messages = batch.messages.map(m => ({
+    id: m.id,
+    timestamp: m.timestamp,
+    body: parseQueueMessage(schema, m.body),
+  }));
+  return { queue: batch.queue, messages };
+}

--- a/packages/common/tests/queue.test.ts
+++ b/packages/common/tests/queue.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { NewContentMessageSchema } from '../src/types/queueMessages';
+import {
+  parseQueueMessage,
+  parseMessageBatch,
+  serializeQueueMessage,
+  RawMessageBatch,
+} from '../src/queue';
+import { MessageProcessingError } from '../src/errors/ServiceError';
+
+const validMessage = {
+  id: '1',
+  userId: 'u',
+  category: 'note',
+};
+
+describe('queue message helpers', () => {
+  it('serializes and parses a message', () => {
+    const str = serializeQueueMessage(NewContentMessageSchema, validMessage);
+    const parsed = parseQueueMessage(NewContentMessageSchema, str);
+    expect(parsed).toEqual({ id: '1', userId: 'u', category: 'note' });
+  });
+
+  it('fails serialization when the message does not match the schema', () => {
+    const bad = { ...validMessage, id: '' };
+    expect(() =>
+      serializeQueueMessage(NewContentMessageSchema, bad as any)
+    ).toThrow(MessageProcessingError);
+  });
+
+  it('parses a batch', () => {
+    const batch: RawMessageBatch = {
+      queue: 'test',
+      messages: [
+        { id: 'a', timestamp: 1, body: JSON.stringify(validMessage) },
+        { id: 'b', timestamp: 2, body: JSON.stringify({ id: '2', userId: null }) },
+      ],
+    };
+    const parsed = parseMessageBatch(NewContentMessageSchema, batch);
+    expect(parsed.messages).toHaveLength(2);
+    expect(parsed.messages[0].body).toEqual(validMessage);
+    expect(parsed.messages[1].body).toEqual({ id: '2', userId: null });
+  });
+
+  it('throws when parsing invalid JSON', () => {
+    expect(() =>
+      parseQueueMessage(NewContentMessageSchema, '{foo:')
+    ).toThrow(MessageProcessingError);
+  });
+
+  it('throws when a message fails validation', () => {
+    const invalid = JSON.stringify({ id: '' });
+    expect(() =>
+      parseQueueMessage(NewContentMessageSchema, invalid)
+    ).toThrow(MessageProcessingError);
+  });
+
+  it('throws when a batch message is invalid', () => {
+    const batch: RawMessageBatch = {
+      queue: 'test',
+      messages: [
+        { id: 'a', timestamp: 1, body: JSON.stringify(validMessage) },
+        { id: 'b', timestamp: 2, body: JSON.stringify({ id: '' }) },
+      ],
+    };
+    expect(() => parseMessageBatch(NewContentMessageSchema, batch)).toThrow(
+      MessageProcessingError
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- expand queue message helper tests to cover error scenarios and batch parsing

## Testing
- `just build`
- `just lint`
- `just test`
