### PR TITLE
Add typed metadata helper for vector upsert

### DIFF
--- a/services/constellation/src/services/vectorize.ts
+++ b/services/constellation/src/services/vectorize.ts
@@ -10,6 +10,7 @@ import {
 import { assertValid, VectorizeError, toDomeError } from '../utils/errors';
 import { sliceIntoBatches } from '../utils/batching';
 import { retryAsync, RetryConfig } from '../utils/retry';
+import { toIndexMetadata } from '../utils/metadata';
 
 /* ------------------------------------------------------------------ */
 /*  configuration                                                     */
@@ -132,7 +133,7 @@ export class VectorizeService {
             batch.map(v => ({
               id: v.id,
               values: v.values,
-              metadata: v.metadata as any, // Reverting due to type incompatibility with VectorizeIndex
+              metadata: toIndexMetadata(v.metadata),
             })),
           );
           getLogger().info({ ...baseCtx, attempt: currentAttempt }, 'Batch upserted');

--- a/services/constellation/src/utils/metadata.ts
+++ b/services/constellation/src/utils/metadata.ts
@@ -1,0 +1,9 @@
+import { VectorMeta } from '@dome/common';
+
+/**
+ * Convert our strongly typed {@link VectorMeta} into the shape
+ * expected by Cloudflare's {@link VectorizeVector} metadata.
+ */
+export function toIndexMetadata(meta: VectorMeta): VectorizeVector['metadata'] {
+  return { ...meta } as Record<string, VectorizeVectorMetadata>;
+}

--- a/services/constellation/tests/metadata.test.ts
+++ b/services/constellation/tests/metadata.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { toIndexMetadata } from '../src/utils/metadata';
+import { VectorMeta } from '@dome/common';
+
+const meta: VectorMeta = {
+  userId: 'u1',
+  contentId: 'c1',
+  category: 'note',
+  mimeType: 'text/plain',
+  createdAt: 1,
+  version: 1,
+};
+
+describe('toIndexMetadata', () => {
+  it('converts VectorMeta to index metadata shape', () => {
+    const res = toIndexMetadata(meta);
+    expect(res).toMatchObject(meta);
+  });
+});


### PR DESCRIPTION
## Summary
- add `toIndexMetadata` helper to convert `VectorMeta` to `Vectorize` format
- use helper in `VectorizeService.upsertBatch`
- test metadata conversion

## Testing
- `just lint`
- `just test`
- `just build`
