### PR TITLE
Add wrangler types script

### DIFF
--- a/docs/services/constellation.md
+++ b/docs/services/constellation.md
@@ -515,20 +515,28 @@ Logs are formatted as JSON with consistent fields:
 
 2. Set up local Vectorize index:
 
-   ```bash
-   wrangler vectorize create notes_index --dimensions 1536
-   ```
+```bash
+wrangler vectorize create notes_index --dimensions 1536
+```
 
-3. Run the service locally:
+3. Generate Worker configuration types:
 
-   ```bash
-   just dev constellation
-   ```
+```bash
+pnpm types
+```
 
-4. For queue consumer testing:
-   ```bash
-   wrangler dev --queue-consumer
-   ```
+This runs `wrangler types` to regenerate `worker-configuration.d.ts`.
+
+4. Run the service locally:
+
+```bash
+just dev constellation
+```
+
+5. For queue consumer testing:
+```bash
+wrangler dev --queue-consumer
+```
 
 ### Testing
 

--- a/services/constellation/package.json
+++ b/services/constellation/package.json
@@ -14,15 +14,16 @@
       "types": "./dist/client/index.d.ts"
     }
   },
-  "scripts": {
-    "build": "tsc",
-    "dev": "wrangler dev --queue-consumer",
-    "deploy": "wrangler deploy",
-    "lint": "eslint src --ext .ts,.tsx",
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
-  },
+    "scripts": {
+      "build": "tsc",
+      "dev": "wrangler dev --queue-consumer",
+      "deploy": "wrangler deploy",
+      "types": "wrangler types",
+      "lint": "eslint src --ext .ts,.tsx",
+      "test": "vitest run",
+      "test:watch": "vitest",
+      "test:coverage": "vitest run --coverage"
+    },
   "dependencies": {
     "@dome/common": "workspace:*",
     "@dome/errors": "workspace:*",


### PR DESCRIPTION
## Summary
- document how to regenerate worker-configuration.d.ts
- add a `types` npm script in Constellation service

## Testing
- `just build`
- `just lint`
- `just test`
