### PR TITLE
Refine Silo bindings and AI model typing

### DIFF
--- a/services/ai-processor/src/index.ts
+++ b/services/ai-processor/src/index.ts
@@ -12,6 +12,7 @@ import { toDomeError } from '@dome/errors';
 import { createLlmService } from './services/llmService';
 import { EnrichedContentMessage, NewContentMessage, SiloContentMetadata } from '@dome/common';
 import { SiloClient, SiloBinding } from '@dome/silo/client';
+import type { ServiceEnv } from './types';
 import { z } from 'zod';
 import { sendTodosToQueue } from './todos';
 import {
@@ -36,10 +37,10 @@ import { ContentProcessor } from './utils/processor';
  * @param env Environment bindings
  * @returns Service instances
  */
-const buildServices = (env: Env) => {
+const buildServices = (env: ServiceEnv) => {
   const first = {
     llm: createLlmService(env),
-    silo: new SiloClient(env.SILO as unknown as SiloBinding),
+    silo: new SiloClient(env.SILO),
   };
 
   return {
@@ -57,7 +58,7 @@ const buildServices = (env: Env) => {
  *
  * It also provides RPC functions for reprocessing content.
  */
-export default class AiProcessor extends WorkerEntrypoint<Env> {
+export default class AiProcessor extends WorkerEntrypoint<ServiceEnv> {
   /** Lazily created bundle of service clients (re‑used for every call) */
   private _services?: ReturnType<typeof buildServices>;
   private get services() {

--- a/services/ai-processor/src/services/llmService.ts
+++ b/services/ai-processor/src/services/llmService.ts
@@ -1,5 +1,6 @@
 import { getLogger, logError, trackOperation } from '../utils/logging';
 import { toDomeError, LLMProcessingError, assertValid } from '../utils/errors';
+import type { ServiceEnv } from '../types';
 import { getSchemaForContentType, getSchemaInstructions } from '../schemas';
 import {
   truncateToTokenLimit,
@@ -10,7 +11,7 @@ import {
 } from '@dome/common';
 
 /** Factory */
-export function createLlmService(env: Env): LlmService {
+export function createLlmService(env: ServiceEnv): LlmService {
   return new LlmService(env);
 }
 
@@ -22,7 +23,7 @@ export class LlmService {
 
   private readonly logger = getLogger().child({ component: 'LlmService' });
 
-  constructor(private readonly env: Env) {
+  constructor(private readonly env: ServiceEnv) {
     // Note: LLM configuration is now initialized automatically by the common package
   }
 

--- a/services/ai-processor/src/types.ts
+++ b/services/ai-processor/src/types.ts
@@ -1,59 +1,27 @@
 import { SiloBatchGetInput, SiloContentBatch } from '@dome/common';
+import { SiloBinding } from '@dome/silo/client';
 import { z } from 'zod';
 
 /**
  * Environment interface for AI Processor
  */
-interface Env {
-  // Bindings
-  AI: AI;
-  ENRICHED_CONTENT?: Queue<any>;
-  RATE_LIMIT_DLQ?: Queue<any>;
-  TODOS?: Queue<any>;
-  SILO: any;
-
-  // Environment variables
+export interface ServiceEnv {
+  AI: Ai;
+  ENRICHED_CONTENT: Queue;
+  RATE_LIMIT_DLQ: Queue;
+  TODOS: Queue;
+  SILO: SiloBinding;
   AI_MODEL_NAME?: string;
   AI_TOKEN_LIMIT?: string;
 }
 
-/**
- * AI interface for Cloudflare AI
- */
-interface AI {
-  run<T extends keyof AiModels>(model: T, options: any): Promise<AiResponse>;
-}
-
-/**
- * AI models available in Cloudflare
- */
-interface AiModels {
-  '@cf/google/gemma-7b-it-lora': any;
-  '@cf/meta/llama-2-7b-chat-int8': any;
-  '@cf/mistral/mistral-7b-instruct-v0.1': any;
-  '@cf/meta/llama-3-8b-instruct': any;
-  '@cf/meta/llama-3-70b-instruct': any;
-  '@cf/google/gemma-3-12b-it': any; // Added additional model
-  [key: string]: any; // Allow any other string model names
-}
-
-/**
- * AI response type
- */
-type AiResponse = {
-  response?: string;
-  [key: string]: any;
-};
 
 // Define Cloudflare Workers types
-export interface Queue<T> {
+export interface GenericQueue<T> {
   send(message: T): Promise<void>;
   sendBatch(messages: T[]): Promise<void>;
 }
 
-export interface SiloBinding {
-  batchGet(data: SiloBatchGetInput): Promise<SiloContentBatch>;
-}
 
 /**
  * Message batch from queue

--- a/services/ai-processor/src/utils/processor.ts
+++ b/services/ai-processor/src/utils/processor.ts
@@ -33,6 +33,7 @@ import type {
   DefaultProcessingResult,
 } from '../schemas';
 import type { SiloClient } from '@dome/silo/client';
+import type { ServiceEnv } from '../types';
 
 // This is a generic representation. The actual 'parsed' part will be one of the *ProcessingResult types.
 export type LlmProcessingResult = (
@@ -67,7 +68,7 @@ interface ExistingMetadata {
  * ContentProcessor – no I/O side‑effects beyond env queues.
  */
 export class ContentProcessor {
-  constructor(private readonly env: Env, private readonly services: ProcessorServices) {}
+  constructor(private readonly env: ServiceEnv, private readonly services: ProcessorServices) {}
 
   /** Process a single NEW_CONTENT message (idempotent). */
   async processMessage(msg: NewContentMessage, requestId: string): Promise<void> {

--- a/services/constellation/src/services/embedder.ts
+++ b/services/constellation/src/services/embedder.ts
@@ -285,11 +285,7 @@ export class Embedder {
    */
   private async callAiService(texts: string[]): Promise<AiTextEmbeddingOutput> {
     const input: AiTextEmbeddingInput = { text: texts };
-    // Assuming this.ai.run is compatible with this signature.
-    // If this.ai is a more generic binding, further type refinement or casting might be needed
-    // at the binding level. For now, we cast to 'any' to match previous behavior
-    // pending a more precise AiModels type.
-    const response = await this.ai.run(this.config.model as any, input);
+    const response = await this.ai.run(this.config.model, input);
 
     // Basic type guard for the response
     if (

--- a/services/constellation/src/types.ts
+++ b/services/constellation/src/types.ts
@@ -114,12 +114,7 @@ export interface CFExecutionContext extends ExecutionContext {
  * Represents the known AI models that can be used with the Ai.run method.
  * This helps in providing type safety when specifying models.
  */
-export type KnownAiModels =
-  | '@cf/baai/bge-large-en-v1.5'
-  | '@cf/baai/bge-base-en-v1.5'
-  | '@cf/baai/bge-small-en-v1.5'
-  // Add other known models here as they are supported or used
-  | (string & {}); // Allows for other string models while providing autocompletion for known ones
+export type KnownAiModels = keyof AiModels;
 
 /**
  * Expected structure of the input for AI text embedding models.

--- a/services/dome-api/src/services/serviceFactory.ts
+++ b/services/dome-api/src/services/serviceFactory.ts
@@ -100,7 +100,7 @@ export class DefaultServiceFactory implements ServiceFactory {
     let service = this.siloServices.get(env);
     if (!service) {
       this.logger.debug('Creating new SiloClient instance');
-      service = new SiloClient(env.SILO as unknown as SiloBinding, env.SILO_INGEST_QUEUE);
+      service = new SiloClient(env.SILO, env.SILO_INGEST_QUEUE);
       this.siloServices.set(env, service);
     }
     return service;

--- a/services/tsunami/src/providers/github.ts
+++ b/services/tsunami/src/providers/github.ts
@@ -14,6 +14,7 @@ import {
 } from '../services/metadataHeaderService';
 import { IgnoreFileService } from '../services/ignoreFileService';
 import { BaseProvider } from './base';
+import type { ServiceEnv } from '../resourceObject';
 
 /* ─── constants ────────────────────────────────────────────────────────── */
 
@@ -61,7 +62,7 @@ export class GithubProvider extends BaseProvider implements Provider {
   private headers: Record<string, string>;
   private ignoreFileService: IgnoreFileService;
 
-  constructor(env: Env) {
+  constructor(env: ServiceEnv) {
     super();
     const token = (env as any).GITHUB_TOKEN ?? '';
     this.headers = {

--- a/services/tsunami/src/providers/notion/auth.ts
+++ b/services/tsunami/src/providers/notion/auth.ts
@@ -8,6 +8,7 @@ import { getLogger, metrics } from '@dome/common';
 import { ServiceError } from '@dome/common/src/errors';
 import { TokenService, OAuthTokenRecord } from '../../services/tokenService'; // Corrected path
 import type { NotionOAuthDetails } from '../../client/types'; // Corrected path
+import type { ServiceEnv } from '../../resourceObject';
 
 /**
  * Notion OAuth Token Response
@@ -41,7 +42,7 @@ export class NotionAuthManager {
   // private tokenStore: Map<string, string> = new Map(); // Replaced with TokenService
   private tokenService: TokenService;
 
-  constructor(env: Env) {
+  constructor(env: ServiceEnv) {
     this.clientId = (env as any).NOTION_CLIENT_ID || '';
     this.clientSecret = (env as any).NOTION_CLIENT_SECRET || '';
     this.redirectUri = (env as any).NOTION_REDIRECT_URI || '';

--- a/services/tsunami/src/providers/notion/index.ts
+++ b/services/tsunami/src/providers/notion/index.ts
@@ -18,6 +18,7 @@ import { injectMetadataHeader } from '../../services/metadataHeaderService';
 import { BaseProvider } from '../base';
 import { NotionClient } from './client';
 import { NotionAuthManager } from './auth';
+import type { ServiceEnv } from '../../resourceObject';
 
 /**
  * Notion Provider implementation
@@ -27,7 +28,7 @@ export class NotionProvider extends BaseProvider implements Provider {
   private notionClient: NotionClient;
   private authManager: NotionAuthManager;
 
-  constructor(env: Env) {
+  constructor(env: ServiceEnv) {
     const apiKey = (env as any).NOTION_API_KEY ?? '';
     super();
     this.authManager = new NotionAuthManager(env);

--- a/services/tsunami/src/providers/website.ts
+++ b/services/tsunami/src/providers/website.ts
@@ -8,6 +8,7 @@ import { SiloSimplePutInput, ContentCategory, MimeType } from '@dome/common';
 import { Provider, PullOpts, PullResult } from '.';
 import { logError, metrics } from '@dome/common';
 import { BaseProvider } from './base';
+import type { ServiceEnv } from '../resourceObject';
 import { RobotsChecker } from './website/robotsChecker';
 import { WebsiteCrawler } from './website/websiteCrawler';
 import { ContentExtractor } from './website/contentExtractor';
@@ -52,7 +53,7 @@ export class WebsiteProvider extends BaseProvider implements Provider {
   private crawler: WebsiteCrawler;
   private extractor: ContentExtractor;
 
-  constructor(env: Env) {
+  constructor(env: ServiceEnv) {
     super(); // initialise BaseProvider
     // Initialize components
     this.robotsChecker = new RobotsChecker(UA);

--- a/services/tsunami/src/services/syncPlanService.ts
+++ b/services/tsunami/src/services/syncPlanService.ts
@@ -1,5 +1,6 @@
 import { ulid } from 'ulid';
 import { getLogger, logError, metrics, trackOperation, getRequestId } from '@dome/common';
+import type { ServiceEnv } from '../resourceObject';
 import {
   NotFoundError,
   ConflictError,
@@ -23,7 +24,7 @@ export class SyncPlanService {
   private logger = getLogger();
   private domain = 'tsunami.syncPlanService';
 
-  constructor(private env: Env) {}
+  constructor(private env: ServiceEnv) {}
 
   /* ─────────── Sync‑plan CRUD ─────────── */
 
@@ -300,4 +301,4 @@ export class SyncPlanService {
 }
 
 /* factory so the rest of the codebase changes ⟶ one line */
-export const createSyncPlanService = (env: Env) => new SyncPlanService(env);
+export const createSyncPlanService = (env: ServiceEnv) => new SyncPlanService(env);


### PR DESCRIPTION
## Summary
- tighten AI model types using `keyof AiModels`
- remove casts from `Embedder.callAiService`
- type worker environments with service-specific `ServiceEnv`
- apply `ServiceEnv` in Silo client consumers

## Testing
- `just build`
- `just lint`
- `just test`
