### PR TITLE
Add Constellation service tests

### DIFF
--- a/services/constellation/tests/embedder.test.ts
+++ b/services/constellation/tests/embedder.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('@dome/common', () => ({ getLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }), PUBLIC_USER_ID: 'public', withContext: async (_m: any, fn: any) => fn({}) }));
+vi.mock('../src/utils/errors', () => ({ EmbeddingError: class extends Error {}, assertValid: () => {}, assertExists: () => {}, toDomeError: (e: any) => e }));
+vi.mock('@dome/errors', () => ({}));
+import { Embedder } from '../src/services/embedder';
+
+vi.mock('../src/utils/logging', () => ({
+  getLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  logError: vi.fn(),
+  constellationMetrics: {
+    counter: vi.fn(),
+    gauge: vi.fn(),
+    timing: vi.fn(),
+    startTimer: () => ({ stop: vi.fn() }),
+  },
+}));
+
+describe('Embedder', () => {
+  it('returns empty array for empty input', async () => {
+    const ai = { run: vi.fn() } as any;
+    const embedder = new Embedder(ai);
+    const result = await embedder.embed([]);
+    expect(result).toEqual([]);
+    expect(ai.run).not.toHaveBeenCalled();
+  });
+
+  it('calls AI once for small batches', async () => {
+    const ai = {
+      run: vi.fn(async (_model: string, input: any) => ({
+        shape: [input.text.length, 1],
+        data: input.text.map((t: string) => [t.length]),
+      })),
+    } as any;
+    const embedder = new Embedder(ai, { maxBatchSize: 5 });
+    const texts = ['a', 'bb'];
+    const res = await embedder.embed(texts);
+    expect(res).toEqual([[1], [2]]);
+    expect(ai.run).toHaveBeenCalledTimes(1);
+  });
+
+  it('splits input into multiple batches', async () => {
+    const ai = {
+      run: vi.fn(async (_model: string, input: any) => ({
+        shape: [input.text.length, 1],
+        data: input.text.map((t: string) => [t.length]),
+      })),
+    } as any;
+    const embedder = new Embedder(ai, { maxBatchSize: 2 });
+    const texts = ['one', 'two', 'three', 'four', 'five'];
+    const res = await embedder.embed(texts);
+    expect(res.length).toBe(5);
+    expect(ai.run).toHaveBeenCalledTimes(3);
+  });
+});

--- a/services/constellation/tests/preprocessor.test.ts
+++ b/services/constellation/tests/preprocessor.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { TextPreprocessor } from '../src/services/preprocessor';
+
+describe('TextPreprocessor', () => {
+  it('normalizes text by trimming and removing excess whitespace', () => {
+    const p = new TextPreprocessor();
+    const input = ' Hello   world!!!\n\nHow are   you?  ';
+    const expected = 'Hello world!!! How are you?';
+    expect(p.normalize(input)).toBe(expected);
+  });
+
+  it('chunks long text with overlap', () => {
+    const p = new TextPreprocessor({ maxChunkSize: 10, overlapSize: 2, minChunkSize: 3 });
+    const chunks = p.chunk('abcdefghijklmnopqrstuvwxyz');
+    expect(chunks).toEqual(['abcdefghij', 'ijklmnopqr', 'qrstuvwxyz']);
+  });
+
+  it('processes text using normalize and chunk', () => {
+    const p = new TextPreprocessor({ maxChunkSize: 10, overlapSize: 2, minChunkSize: 3 });
+    const result = p.process('  abcdefghijklmnopqrstuvwxyz  ');
+    expect(result).toEqual(['abcdefghij', 'ijklmnopqr', 'qrstuvwxyz']);
+  });
+});

--- a/services/constellation/tests/queue.integration.test.ts
+++ b/services/constellation/tests/queue.integration.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('cloudflare:workers', () => ({ WorkerEntrypoint: class { env: any; constructor(_c: any, env: any) { this.env = env; } } }));
+vi.mock('@dome/common', () => ({
+  getLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  PUBLIC_USER_ID: 'public',
+  withContext: async (_m: any, fn: any) => fn({}),
+}));
+vi.mock('@dome/errors', () => ({}));
+vi.mock('../src/utils/errors', () => ({
+  assertValid: () => {},
+  assertExists: () => {},
+  toDomeError: (e: any) => e,
+  VectorizeError: class extends Error {},
+  EmbeddingError: class extends Error {},
+}));
+vi.mock('@dome/silo/client', () => ({ SiloClient: class { constructor(){} get(){return Promise.resolve({ id: 'id', userId: 'u', body: 'text' });} } }));
+import Constellation from '../src';
+
+vi.mock('../src/utils/logging', () => ({
+  getLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  logError: vi.fn(),
+  trackOperation: async (_n: string, fn: () => Promise<any>) => fn(),
+  constellationMetrics: {
+    counter: vi.fn(),
+    gauge: vi.fn(),
+    timing: vi.fn(),
+    startTimer: () => ({ stop: vi.fn() }),
+  },
+}));
+
+describe('queue integration', () => {
+  it('parses messages and embeds valid items', async () => {
+    const env = { EMBED_DEAD: {} } as any;
+    const ctx = {} as any;
+    const worker = new Constellation(ctx, env);
+
+    const parseSpy = vi.spyOn(worker as any, 'parseMessage').mockResolvedValue({ id: '1', userId: 'u', body: 'text' });
+    const embedSpy = vi.spyOn(worker as any, 'embedBatch').mockResolvedValue(1);
+
+    const mkMsg = (id: string) => ({
+      id,
+      timestamp: new Date(),
+      body: {},
+      attempts: 0,
+      ack: vi.fn(),
+      retry: vi.fn(),
+    });
+
+    const batch = { queue: 'q', messages: [mkMsg('a'), mkMsg('b')], ackAll: vi.fn(), retryAll: vi.fn() } as any;
+
+    await worker.queue(batch);
+
+    expect(parseSpy).toHaveBeenCalledTimes(2);
+    expect(embedSpy).toHaveBeenCalledTimes(1);
+    batch.messages.forEach((m: any) => expect(m.ack).toHaveBeenCalled());
+  });
+});

--- a/services/constellation/tests/vectorize.service.test.ts
+++ b/services/constellation/tests/vectorize.service.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('@dome/common', () => ({ getLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }), PUBLIC_USER_ID: 'public', withContext: async (_m: any, fn: any) => fn({}) }));
+vi.mock('@dome/errors', () => ({}));
+vi.mock('../src/utils/errors', () => ({ assertValid: () => {}, assertExists: () => {}, VectorizeError: class extends Error {}, toDomeError: (e:any)=>e }));
+import { VectorizeService } from '../src/services/vectorize';
+import { PUBLIC_USER_ID } from '@dome/common';
+
+vi.mock('../src/utils/logging', () => ({
+  getLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  logError: vi.fn(),
+  trackOperation: async (_name: string, fn: () => Promise<any>) => fn(),
+  constellationMetrics: {
+    counter: vi.fn(),
+    gauge: vi.fn(),
+    startTimer: () => ({ stop: vi.fn() }),
+    timing: vi.fn(),
+  },
+}));
+
+describe('VectorizeService', () => {
+  it('does nothing for empty upsert', async () => {
+    const idx = { upsert: vi.fn(), describe: vi.fn(async () => ({ vectorCount: 0, dimensions: 0 })) } as any;
+    const svc = new VectorizeService(idx, { maxBatchSize: 2 });
+    await svc.upsert([]);
+    expect(idx.upsert).not.toHaveBeenCalled();
+  });
+
+  it('splits upsert into batches', async () => {
+    const idx = {
+      upsert: vi.fn(async () => {}),
+      describe: vi.fn(async () => ({ vectorCount: 0, dimensions: 0 })),
+    } as any;
+    const svc = new VectorizeService(idx, { maxBatchSize: 2 });
+    const vecs = [1,2,3,4,5].map(i => ({ id: `${i}`, values: [i], metadata: { userId: 'u1' } }));
+    await svc.upsert(vecs as any);
+    expect(idx.upsert).toHaveBeenCalledTimes(3);
+  });
+
+  it('merges PUBLIC_USER_ID on query', async () => {
+    const idx = {
+      query: vi.fn(async (_v: number[], opts: any) => ({ matches: [], ...opts })),
+      describe: vi.fn(),
+    } as any;
+    const svc = new VectorizeService(idx, {});
+    await svc.query([1,2], { userId: 'u1' }, 5);
+    expect(idx.query).toHaveBeenCalledWith(
+      [1,2],
+      expect.objectContaining({
+        filter: { userId: { $in: ['u1', PUBLIC_USER_ID] } },
+        topK: 5,
+        returnMetadata: true,
+      }),
+    );
+  });
+});

--- a/services/constellation/vitest.config.ts
+++ b/services/constellation/vitest.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 // Configure vitest to use more memory and run tests serially
 export default defineConfig({
+  resolve: {
+    alias: {
+      '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
+      '@dome/errors': path.resolve(__dirname, '../../packages/errors/src'),
+    },
+  },
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts'],


### PR DESCRIPTION
## Summary
- add unit tests for `TextPreprocessor`, `Embedder`, and `VectorizeService`
- add integration test for queue batch processing
- fix Vitest alias config for Constellation service

## Testing
- `just lint`
- `just build`
- `just test`
