### PR TITLE
Use queue helpers in Constellation worker

### DIFF
--- a/services/constellation/vitest.config.ts
+++ b/services/constellation/vitest.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 // Configure vitest to use more memory and run tests serially
 export default defineConfig({
@@ -6,6 +7,10 @@ export default defineConfig({
     environment: 'node',
     include: ['tests/**/*.test.ts'],
     globals: true,
+    alias: {
+      '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
+      '@dome/errors': path.resolve(__dirname, '../../packages/errors/src'),
+    },
     setupFiles: ['tests/setup.js'],
     // Run tests serially to reduce memory pressure
     singleThread: true,


### PR DESCRIPTION
## Summary
- refactor Constellation queue handler to use `parseMessageBatch`
- update embedBatch to accept parsed messages
- adjust RPC embed to create parsed messages
- configure vitest alias for Constellation tests

## Testing
- `just lint`
- `just build`
- `just test`