### PR TITLE
Fix queue message serialization

### DIFF
--- a/services/ai-processor/tests/todos.test.ts
+++ b/services/ai-processor/tests/todos.test.ts
@@ -23,7 +23,8 @@ describe('sendTodosToQueue', () => {
     const q = makeQueue();
     await sendTodosToQueue(baseContent as any, q as any);
     expect(q.send).toHaveBeenCalledTimes(1);
-    expect(q.send.mock.calls[0][0]).toMatchObject({ userId: 'u1', description: 'a' });
+    const sent = JSON.parse(q.send.mock.calls[0][0]);
+    expect(sent).toMatchObject({ userId: 'u1', description: 'a' });
   });
 
   it('skips when no userId', async () => {

--- a/services/silo/src/services/queueService.ts
+++ b/services/silo/src/services/queueService.ts
@@ -1,5 +1,11 @@
-import { getLogger, logError, metrics } from '@dome/common';
-import { NewContentMessage } from '@dome/common';
+import {
+  getLogger,
+  logError,
+  metrics,
+  NewContentMessage,
+  NewContentMessageSchema,
+  serializeQueueMessage,
+} from '@dome/common';
 
 /**
  * QueueService - A wrapper around Queue operations
@@ -16,8 +22,9 @@ export class QueueService {
     const startTime = Date.now();
 
     try {
-      await this.env.NEW_CONTENT_CONSTELLATION.send(message);
-      await this.env.NEW_CONTENT_AI.send(message);
+      const serialized = serializeQueueMessage(NewContentMessageSchema, message);
+      await this.env.NEW_CONTENT_CONSTELLATION.send(serialized);
+      await this.env.NEW_CONTENT_AI.send(serialized);
 
       metrics.timing('silo.queue.send.latency_ms', Date.now() - startTime);
       getLogger().info({ message }, 'Message sent to NEW_CONTENT queue');

--- a/services/todos/src/client/index.ts
+++ b/services/todos/src/client/index.ts
@@ -18,7 +18,7 @@ import {
   TodoQueueItem,
   TodoQueueItemSchema,
 } from '../types';
-import { getLogger } from '@dome/common';
+import { getLogger, serializeQueueMessage } from '@dome/common';
 import { createServiceMetrics } from '@dome/common';
 
 export {
@@ -165,7 +165,7 @@ export function createTodosClient(
  * @returns The result of sending to the queue
  */
 export async function sendTodosToQueue(
-  queue: Queue<TodoQueueItem>,
+  queue: Queue,
   todos: TodoQueueItem | TodoQueueItem[],
   metadata: Record<string, any> = {},
 ): Promise<void> {
@@ -195,7 +195,8 @@ export async function sendTodosToQueue(
   try {
     // Send each todo individually since queue.send doesn't support arrays
     for (const todo of todosArray) {
-      await queue.send(todo);
+      const serialized = serializeQueueMessage(TodoQueueItemSchema, todo);
+      await queue.send(serialized);
     }
 
     logger.info(


### PR DESCRIPTION
## Summary
- send new content messages as JSON strings
- serialize enriched content and todos before queuing
- adjust tests for new serialization behaviour

## Testing
- `just lint`
- `just build`
- `just test`
