### PR TITLE
Fix failing test in todos service

### DIFF
--- a/services/todos/vitest.config.ts
+++ b/services/todos/vitest.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts'],
     globals: true,
+    alias: {
+      '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
+    },
     setupFiles: ['tests/setup.js'],
   },
 });


### PR DESCRIPTION
## Summary
- resolve path alias for `@dome/common` in Todos tests

## Testing
- `just build`
- `just lint`
- `just test`
