### PR TITLE
Fix failing crypto tests

### DIFF
--- a/services/constellation/tests/setup.js
+++ b/services/constellation/tests/setup.js
@@ -1,2 +1,8 @@
-// Minimal test setup
-export {};
+import { webcrypto as crypto } from 'node:crypto';
+
+// Provide a global crypto polyfill for Node versions where it is absent
+// (e.g. Node 16). Vitest uses the Node environment for these tests, so
+// assigning to globalThis ensures APIs like crypto.randomUUID are available.
+if (!globalThis.crypto) {
+  globalThis.crypto = crypto;
+}

--- a/services/todos/vitest.config.ts
+++ b/services/todos/vitest.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts'],
     globals: true,
+    alias: {
+      '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
+    },
     setupFiles: ['tests/setup.js'],
   },
 });


### PR DESCRIPTION
## Summary
- polyfill the global crypto object in Constellation tests

## Testing
- `just build`
- `just lint` (with warnings)
- `just test`
