### PR TITLE
Fix crypto availability in ai-processor tests

### DIFF
--- a/services/ai-processor/tests/setup.ts
+++ b/services/ai-processor/tests/setup.ts
@@ -1,0 +1,9 @@
+import { webcrypto } from 'node:crypto';
+
+if (typeof globalThis.crypto === 'undefined') {
+  // Vitest running under older Node versions may not expose `crypto` globally.
+  // Provide a minimal polyfill so code relying on `crypto` works in tests.
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore - webcrypto is compatible with the Crypto interface expected
+  globalThis.crypto = webcrypto as unknown as Crypto;
+}

--- a/services/ai-processor/vitest.config.ts
+++ b/services/ai-processor/vitest.config.ts
@@ -6,6 +6,7 @@ export default defineConfig({
     environment: 'node',
     globals: true,
     include: ['tests/**/*.test.ts'],
+    setupFiles: ['tests/setup.ts'],
     alias: {
       '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
       '@dome/errors': path.resolve(__dirname, '../../packages/errors/src'),

--- a/services/todos/vitest.config.ts
+++ b/services/todos/vitest.config.ts
@@ -1,10 +1,14 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
   test: {
     environment: 'node',
     include: ['tests/**/*.test.ts'],
     globals: true,
+    alias: {
+      '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
+    },
     setupFiles: ['tests/setup.js'],
   },
 });


### PR DESCRIPTION
## Summary
- polyfill `globalThis.crypto` for the ai-processor tests
- load the setup file in `vitest.config.ts`

## Testing
- `just test`
