### PR TITLE
Centralize vitest config

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,20 +1,19 @@
-import { defineConfig } from 'vitest/config';
-import path from 'path';
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.base.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['**/*.test.ts', '**/*.test.js'],
-    root: '.',
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov'],
-      include: ['src/**/*.{ts,js}'],
-      exclude: ['src/**/*.d.ts'],
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      include: ['**/*.test.ts', '**/*.test.js'],
+      root: '.',
+      setupFiles: ['./vitest.setup.js'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'lcov'],
+        include: ['src/**/*.{ts,js}'],
+        exclude: ['src/**/*.d.ts'],
+      },
     },
-    setupFiles: ['./vitest.setup.js'],
-    alias: {
-      '@dome/common': path.resolve(__dirname, '../common/src'),
-    },
-  },
-});
+  }),
+);

--- a/packages/common/vitest.config.ts
+++ b/packages/common/vitest.config.ts
@@ -1,20 +1,17 @@
-import { defineConfig } from 'vitest/config';
-import path from 'path';
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.base.config';
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@dome/common': path.resolve(__dirname, './src'),
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      include: ['**/*.test.ts', '**/*.test.js'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'lcov'],
+        include: ['src/**/*.{ts,js}'],
+        exclude: ['**/node_modules/**', '**/dist/**', 'src/**/*.d.ts'],
+      },
     },
-  },
-  test: {
-    environment: 'node',
-    include: ['**/*.test.ts', '**/*.test.js'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov'],
-      include: ['src/**/*.{ts,js}'],
-      exclude: ['**/node_modules/**', '**/dist/**', 'src/**/*.d.ts'],
-    },
-  },
-});
+  }),
+);

--- a/packages/errors/vitest.config.ts
+++ b/packages/errors/vitest.config.ts
@@ -1,14 +1,17 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.base.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['**/*.test.ts'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov'],
-      include: ['src/**/*.{ts,js}'],
-      exclude: ['**/node_modules/**', '**/dist/**', 'src/**/*.d.ts'],
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      include: ['**/*.test.ts'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'lcov'],
+        include: ['src/**/*.{ts,js}'],
+        exclude: ['**/node_modules/**', '**/dist/**', 'src/**/*.d.ts'],
+      },
     },
-  },
-});
+  }),
+);

--- a/services/ai-processor/vitest.config.ts
+++ b/services/ai-processor/vitest.config.ts
@@ -1,21 +1,16 @@
-import { defineConfig } from 'vitest/config'
-import path from 'path'
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.base.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    globals: true,
-    include: ['tests/**/*.test.ts'],
-    alias: {
-      '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
-      '@dome/errors': path.resolve(__dirname, '../../packages/errors/src'),
-      '@dome/todos': path.resolve(__dirname, '../todos/src'),
-      '@dome/silo': path.resolve(__dirname, '../silo/src'),
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      include: ['tests/**/*.test.ts'],
+      coverage: {
+        reporter: ['text', 'json', 'html'],
+        exclude: ['node_modules/', 'tests/'],
+        provider: 'v8',
+      },
     },
-    coverage: {
-      reporter: ['text', 'json', 'html'],
-      exclude: ['node_modules/', 'tests/'],
-      provider: 'v8',
-    },
-  },
-})
+  }),
+);

--- a/services/auth/vitest.config.ts
+++ b/services/auth/vitest.config.ts
@@ -1,22 +1,18 @@
-import { defineConfig } from 'vitest/config';
-import { resolve } from 'path';
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.base.config';
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@dome/common/errors': resolve(__dirname, '../../packages/errors/src'),
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      include: ['tests/**/*.test.ts'],
+      setupFiles: ['tests/setup.js'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'lcov', 'json', 'html'],
+        include: ['src/**/*.{ts,js}'],
+        exclude: ['src/**/*.d.ts', 'tests/**'],
+      },
     },
-  },
-  test: {
-    environment: 'node',
-    include: ['tests/**/*.test.ts'],
-    globals: true,
-    setupFiles: ['tests/setup.js'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov', 'json', 'html'],
-      include: ['src/**/*.{ts,js}'],
-      exclude: ['src/**/*.d.ts', 'tests/**'],
-    },
-  },
-});
+  }),
+);

--- a/services/chat/vitest.config.ts
+++ b/services/chat/vitest.config.ts
@@ -1,19 +1,17 @@
-import { defineConfig } from 'vitest/config';
-import path from 'path';
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.base.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    globals: true,
-    setupFiles: ['./tests/setup.ts'],
-    alias: {
-      '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      setupFiles: ['./tests/setup.ts'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'json', 'html'],
+        include: ['src/**/*.{ts,js}'],
+        exclude: ['node_modules/', 'tests/', 'src/**/*.d.ts'],
+      },
     },
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'json', 'html'],
-      include: ['src/**/*.{ts,js}'],
-      exclude: ['node_modules/', 'tests/', 'src/**/*.d.ts'],
-    },
-  },
-});
+  }),
+);

--- a/services/constellation/vitest.config.ts
+++ b/services/constellation/vitest.config.ts
@@ -1,41 +1,32 @@
-import { defineConfig } from 'vitest/config';
-import path from 'path';
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.base.config';
 
 // Configure vitest to use more memory and run tests serially
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
-      '@dome/errors': path.resolve(__dirname, '../../packages/errors/src'),
-    },
-  },
-  test: {
-    environment: 'node',
-    include: ['tests/**/*.test.ts'],
-    globals: true,
-    alias: {
-      '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
-      '@dome/errors': path.resolve(__dirname, '../../packages/errors/src'),
-    },
-    setupFiles: ['tests/setup.js'],
-    // Run tests serially to reduce memory pressure
-    singleThread: true,
-    // Increase Node.js memory limit using the runner process args
-    testTimeout: 30000, // Increase test timeout to allow for garbage collection
-    hookTimeout: 30000,
-    // Using process.env is one of the reliable ways to increase Node.js heap size
-    environmentOptions: {
-      env: {
-        NODE_OPTIONS: '--max-old-space-size=4096',
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      include: ['tests/**/*.test.ts'],
+      setupFiles: ['tests/setup.js'],
+      // Run tests serially to reduce memory pressure
+      singleThread: true,
+      // Increase Node.js memory limit using the runner process args
+      testTimeout: 30000, // Increase test timeout to allow for garbage collection
+      hookTimeout: 30000,
+      // Using process.env is one of the reliable ways to increase Node.js heap size
+      environmentOptions: {
+        env: {
+          NODE_OPTIONS: '--max-old-space-size=4096',
+        },
+      },
+      // Allow garbage collector to run between tests
+      teardownTimeout: 5000,
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'lcov', 'json', 'html'],
+        include: ['src/**/*.{ts,js}'],
+        exclude: ['src/**/*.d.ts', 'tests/**'],
       },
     },
-    // Allow garbage collector to run between tests
-    teardownTimeout: 5000,
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov', 'json', 'html'],
-      include: ['src/**/*.{ts,js}'],
-      exclude: ['src/**/*.d.ts', 'tests/**'],
-    },
-  },
-});
+  }),
+);

--- a/services/dome-api/vitest.config.ts
+++ b/services/dome-api/vitest.config.ts
@@ -1,37 +1,19 @@
-import { defineConfig } from 'vitest/config';
-import path from 'path';
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.base.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['**/*.test.ts', '**/*.test.js'],
-    root: '.',
-    coverage: {
-      provider: 'c8',
-      reporter: ['text', 'lcov'],
-      include: ['src/**/*.{ts,js}'],
-      exclude: ['src/**/*.d.ts'],
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      include: ['**/*.test.ts', '**/*.test.js'],
+      root: '.',
+      setupFiles: ['./tests/setup.js'],
+      coverage: {
+        provider: 'c8',
+        reporter: ['text', 'lcov'],
+        include: ['src/**/*.{ts,js}'],
+        exclude: ['src/**/*.d.ts'],
+      },
     },
-    setupFiles: ['./tests/setup.js'],
-    alias: {
-      // Corrected assumption: 'packages' is a sibling of 'services' under the monorepo root,
-      // OR 'packages' is directly under the monorepo root 'dome'.
-      // If monorepo root is /home/toda/dev/dome/, and packages is /home/toda/dev/dome/packages/
-      // then from /home/toda/dev/dome/services/dome-api/, the path is ../../packages/common/src
-      '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
-      // Assuming 'chat' is a service sibling to 'dome-api': /home/toda/dev/dome/services/chat
-      '@dome/chat/client': path.resolve(__dirname, '../chat/src/client'),
-      // Assuming 'silo' is a service sibling to 'dome-api': /home/toda/dev/dome/services/silo
-      '@dome/silo/client': path.resolve(__dirname, '../silo/src/client'),
-      // Assuming 'constellation' is a service sibling to 'dome-api': /home/toda/dev/dome/services/constellation
-      '@dome/constellation/client': path.resolve(__dirname, '../constellation/src/client'),
-      // Assuming 'ai-processor' is a service sibling to 'dome-api': /home/toda/dev/dome/services/ai-processor
-      '@dome/ai-processor/client': path.resolve(__dirname, '../ai-processor/src/client'),
-      // Assuming 'tsunami' is a service sibling to 'dome-api': /home/toda/dev/dome/services/tsunami
-      '@dome/tsunami/client': path.resolve(__dirname, '../tsunami/src/client'),
-      // Re-adding alias for @dome/logging, pointing to the package root
-      // Assumes 'packages/logging' exists at ../../packages/logging from dome-api
-      '@dome/logging': path.resolve(__dirname, '../../packages/logging'),
-    },
-  },
-});
+  }),
+);

--- a/services/silo/vitest.config.ts
+++ b/services/silo/vitest.config.ts
@@ -1,19 +1,16 @@
-import { defineConfig } from 'vitest/config'
-import path from 'path'
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.base.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    globals: true,
-    alias: {
-      '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
-      '@dome/errors': path.resolve(__dirname, '../../packages/errors/src'),
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'lcov', 'json', 'html'],
+        include: ['src/**/*.{ts,js}'],
+        exclude: ['src/**/*.d.ts', 'tests/**'],
+      },
     },
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov', 'json', 'html'],
-      include: ['src/**/*.{ts,js}'],
-      exclude: ['src/**/*.d.ts', 'tests/**'],
-    },
-  },
-})
+  }),
+);

--- a/services/todos/vitest.config.ts
+++ b/services/todos/vitest.config.ts
@@ -1,10 +1,12 @@
-import { defineConfig } from 'vitest/config';
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.base.config';
 
-export default defineConfig({
-  test: {
-    environment: 'node',
-    include: ['tests/**/*.test.ts'],
-    globals: true,
-    setupFiles: ['tests/setup.js'],
-  },
-});
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      include: ['tests/**/*.test.ts'],
+      setupFiles: ['tests/setup.js'],
+    },
+  }),
+);

--- a/services/tsunami/vitest.config.ts
+++ b/services/tsunami/vitest.config.ts
@@ -1,22 +1,18 @@
-import { defineConfig } from 'vitest/config';
-import path from 'path';
+import { defineConfig, mergeConfig } from 'vitest/config';
+import baseConfig from '../../vitest.base.config';
 
-export default defineConfig({
-  resolve: {
-    alias: {
-      '@dome/common': path.resolve(__dirname, '../../packages/common/src'),
+export default mergeConfig(
+  baseConfig,
+  defineConfig({
+    test: {
+      include: ['tests/**/*.test.ts'],
+      setupFiles: ['tests/setup.js'],
+      coverage: {
+        provider: 'v8',
+        reporter: ['text', 'lcov', 'json', 'html'],
+        include: ['src/**/*.{ts,js}'],
+        exclude: ['src/**/*.d.ts', 'tests/**'],
+      },
     },
-  },
-  test: {
-    environment: 'node',
-    include: ['tests/**/*.test.ts'],
-    globals: true,
-    setupFiles: ['tests/setup.js'],
-    coverage: {
-      provider: 'v8',
-      reporter: ['text', 'lcov', 'json', 'html'],
-      include: ['src/**/*.{ts,js}'],
-      exclude: ['src/**/*.d.ts', 'tests/**'],
-    },
-  },
-});
+  }),
+);

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,5 @@
+import { webcrypto } from 'node:crypto';
+
+if (!globalThis.crypto) {
+  (globalThis as any).crypto = webcrypto as any;
+}

--- a/vitest.base.config.ts
+++ b/vitest.base.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from 'vitest/config';
+import fs from 'node:fs';
+import path from 'path';
+
+const tsconfig = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, 'tsconfig.json'), 'utf8'),
+);
+
+const alias: Record<string, string> = {};
+for (const [key, paths] of Object.entries(
+  tsconfig.compilerOptions.paths as Record<string, string[]>,
+)) {
+  alias[key.replace(/\/*$/, '')] = path.resolve(
+    __dirname,
+    paths[0].replace(/\/*$/, ''),
+  );
+}
+
+export default defineConfig({
+  resolve: { alias },
+  test: {
+    environment: 'node',
+    globals: true,
+    setupFiles: [path.resolve(__dirname, 'tests/setup.ts')],
+  },
+});


### PR DESCRIPTION
## Summary
- add shared vitest.base.config.ts that reads tsconfig paths
- polyfill crypto in a global test setup
- extend all service and package configs from the base config

## Testing
- `just lint`
- `just test`
- `just build`
