### PR TITLE
Implement presigned URL retrieval for large Silo items

### DIFF
--- a/services/silo/src/controllers/contentController.ts
+++ b/services/silo/src/controllers/contentController.ts
@@ -126,10 +126,11 @@ export class ContentController {
             if (item.size <= SIMPLE_PUT_MAX_SIZE) {
               results[item.id].body = await obj.text();
             } else {
-              // TODO: fix
-              throw new ValidationError('Object too large for simple retrieval', {
-                size: item.size,
-              });
+              // For larger objects, provide a presigned URL for download
+              results[item.id].url = await this.r2Service.createPresignedUrl(
+                item.r2Key,
+                PRESIGNED_URL_TTL_SECONDS,
+              );
             }
           }
         }),

--- a/services/silo/src/services/r2Service.ts
+++ b/services/silo/src/services/r2Service.ts
@@ -134,6 +134,30 @@ export class R2Service {
       throw error;
     }
   }
+
+  /**
+   * Create a presigned URL for an object
+   * @param key The R2 key to sign
+   * @param expiresIn Expiration time in seconds
+   */
+  async createPresignedUrl(key: string, expiresIn: number) {
+    const startTime = Date.now();
+
+    try {
+      const url = await (this.env.BUCKET as any).createPresignedUrl({
+        key,
+        method: 'GET',
+        expiresIn,
+      });
+
+      metrics.timing('silo.r2.presign.latency_ms', Date.now() - startTime);
+      return url.toString();
+    } catch (error) {
+      metrics.increment('silo.r2.errors', 1, { operation: 'presign' });
+      logError(error, 'Error creating presigned URL', { key });
+      throw error;
+    }
+  }
 }
 
 export function createR2Service(env: any): R2Service {


### PR DESCRIPTION
## Summary
- add `createPresignedUrl` helper to `R2Service`
- return a presigned URL from `batchGet` for objects larger than `SIMPLE_PUT_MAX_SIZE`

## Testing
- `just lint`
- `just build`
- `just test`
