### PR TITLE
Remove unused AppError export

### DIFF
--- a/packages/common/src/errors/index.ts
+++ b/packages/common/src/errors/index.ts
@@ -39,9 +39,6 @@ export {
   NotImplementedError,
 };
 
-// For backward compatibility
-// TODO: Remove this export after verifying it's not used anywhere
-export { BaseError as AppError } from './BaseError.js';
 
 /**
  * Extended error interface with additional properties

--- a/tests/controllers/chatController.test.ts
+++ b/tests/controllers/chatController.test.ts
@@ -1,4 +1,3 @@
-import { AppError } from '@dome/common';
 import { Hono } from 'hono';
 // import { ChatController, createChatController } from '../../src/controllers/chatController'; // Commented out
 import { Env, Services } from '../../src/types';


### PR DESCRIPTION
## Summary
- remove deprecated AppError export in common package
- drop unused import from ChatController tests

## Testing
- `pnpm -r test --silent > /tmp/test.log 2>&1`
