### PR TITLE
Replace console.log/warn in API routes

### DIFF
--- a/ui/src/app/api/auth/login/route.ts
+++ b/ui/src/app/api/auth/login/route.ts
@@ -39,7 +39,7 @@ export async function POST(req: NextRequest) {
     const validation = LoginSchema.safeParse(body);
 
     if (!validation.success) {
-      console.log('Login validation failed:', validation.error.flatten());
+      console.error('Login validation failed:', validation.error.flatten());
       return NextResponse.json(
         { message: 'Invalid request body.', errors: validation.error.flatten().fieldErrors },
         { status: 400 },
@@ -53,12 +53,12 @@ export async function POST(req: NextRequest) {
 
     // !!! NEVER compare plain text passwords in production !!!
     if (!user || user.password !== password) {
-      console.log(`Login attempt failed for email: ${email}`);
+      console.error('Login attempt failed for provided email');
       return NextResponse.json({ message: 'Invalid email or password' }, { status: 401 });
     }
     // --- !!! INSECURE MOCK AUTHENTICATION END !!! ---
 
-    console.log(`Login successful for user: ${user.email}`);
+    console.error(`Login successful for user id: ${user.id}`);
 
     // Create JWT containing user claims
     const secret = new TextEncoder().encode(JWT_SECRET);

--- a/ui/src/app/api/auth/logout/route.ts
+++ b/ui/src/app/api/auth/logout/route.ts
@@ -36,7 +36,7 @@ export async function POST(req: NextRequest) {
       maxAge: 0, // Expire the cookie immediately
     });
 
-    console.log('Logout request processed, clearing auth_token cookie.');
+    console.error('Logout request processed, clearing auth_token cookie.');
     return response;
   } catch (error) {
     console.error('Logout API route error:', error);

--- a/ui/src/app/api/auth/me/route.ts
+++ b/ui/src/app/api/auth/me/route.ts
@@ -32,14 +32,14 @@ export async function GET(req: NextRequest) {
   const tokenCookie = cookieStore.get('auth_token');
 
   if (!tokenCookie?.value) {
-    console.log('/api/auth/me: No auth_token cookie found.');
+    console.error('/api/auth/me: No auth_token cookie found.');
     return NextResponse.json({ message: 'Not authenticated: No token found.' }, { status: 401 });
   }
 
   const token = tokenCookie.value;
 
   try {
-    console.log(
+    console.error(
       `/api/auth/me: Forwarding token to ${DOME_API_URL}/auth/verify-token for verification.`,
     );
     const introspectionResponse = await fetch(`${DOME_API_URL}/auth/verify-token`, {
@@ -54,9 +54,7 @@ export async function GET(req: NextRequest) {
       const userData = await introspectionResponse.json();
       // Assuming backend returns { user: { id, email, name } } on success
       if (userData && userData.user) {
-        console.log(
-          `/api/auth/me: Token verified successfully by backend for user: ${userData.user.email}`,
-        );
+        console.error('/api/auth/me: Token verified successfully by backend');
         return NextResponse.json(userData);
       } else {
         console.error(
@@ -81,7 +79,7 @@ export async function GET(req: NextRequest) {
       }
     } else {
       // If backend says token is invalid (e.g., 401, 403)
-      console.warn(
+      console.error(
         `/api/auth/me: Backend token verification failed with status ${introspectionResponse.status}.`,
       );
       const errorBody = await introspectionResponse

--- a/ui/src/app/api/auth/register/route.ts
+++ b/ui/src/app/api/auth/register/route.ts
@@ -28,7 +28,7 @@ export async function POST(req: NextRequest) {
     const validation = RegisterSchema.safeParse(body);
 
     if (!validation.success) {
-      console.log('Registration validation failed:', validation.error.flatten());
+      console.error('Registration validation failed:', validation.error.flatten());
       return NextResponse.json(
         { message: 'Invalid request body.', errors: validation.error.flatten().fieldErrors },
         { status: 400 },
@@ -40,7 +40,7 @@ export async function POST(req: NextRequest) {
     // --- !!! INSECURE MOCK USER CHECK START !!! ---
     const existingUser = users.find(u => u.email === email);
     if (existingUser) {
-      console.log(`Registration attempt failed: Email already exists - ${email}`);
+      console.error('Registration attempt failed: Email already exists');
       return NextResponse.json({ message: 'User with this email already exists' }, { status: 409 }); // 409 Conflict
     }
     // --- !!! INSECURE MOCK USER CHECK END !!! ---
@@ -54,7 +54,7 @@ export async function POST(req: NextRequest) {
     };
 
     users.push(newUser); // Add to mock array
-    console.log(`New user registered: ${email} (ID: ${newUser.id})`);
+    console.error(`New user registered with ID: ${newUser.id}`);
     // --- !!! INSECURE MOCK USER CREATION END !!! ---
 
     // In a real application, you might:

--- a/ui/src/app/api/chat/route.ts
+++ b/ui/src/app/api/chat/route.ts
@@ -15,7 +15,7 @@ import { NextRequest, NextResponse } from 'next/server'; // Use NextRequest
  */
 export async function POST(req: NextRequest) {
   // Changed type to NextRequest
-  console.warn('⚠️ Using MOCK /api/chat endpoint! Replace with actual implementation. ⚠️');
+  console.error('⚠️ Using MOCK /api/chat endpoint! Replace with actual implementation. ⚠️');
   try {
     const body = await req.json();
     // Validate the incoming message structure more robustly if needed

--- a/ui/src/app/api/search/route.ts
+++ b/ui/src/app/api/search/route.ts
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
   // Extract and validate Authorization header
   const authorizationHeader = request.headers.get('Authorization');
   if (!authorizationHeader) {
-    console.warn('/api/search: Missing Authorization header.');
+    console.error('/api/search: Missing Authorization header.');
     return NextResponse.json(
       { message: 'Unauthorized: Authorization header required.' },
       { status: 401 },
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest) {
   const token = authorizationHeader.startsWith('Bearer ') ? authorizationHeader.substring(7) : null;
 
   if (!token) {
-    console.warn('/api/search: Invalid or missing Bearer token in Authorization header.');
+    console.error('/api/search: Invalid or missing Bearer token in Authorization header.');
     return NextResponse.json({ message: 'Unauthorized: Invalid token format.' }, { status: 401 });
   }
 
@@ -59,7 +59,7 @@ export async function GET(request: NextRequest) {
     externalApiUrl.searchParams.append('category', category);
   }
 
-  console.log(`Proxying search request to: ${externalApiUrl.toString()}`);
+  console.error(`Proxying search request to: ${externalApiUrl.toString()}`);
 
   try {
     // Make the request to the external API, forwarding the token

--- a/ui/src/app/api/settings/integrations/github/callback/route.ts
+++ b/ui/src/app/api/settings/integrations/github/callback/route.ts
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest) {
   const clientFinalRedirectPath = encodedClientRedirectPath
     ? decodeURIComponent(encodedClientRedirectPath)
     : '/settings/integrations';
-  console.log(
+  console.error(
     `GitHub callback state received. Extracted redirect path: ${clientFinalRedirectPath}`,
   );
   // --- End State Verification ---
@@ -87,7 +87,7 @@ export async function GET(request: NextRequest) {
 
   try {
     // --- 3. Exchange Code for Access Token ---
-    console.log('Exchanging GitHub code for access token...');
+    console.error('Exchanging GitHub code for access token...');
     const tokenResponse = await fetch('https://github.com/login/oauth/access_token', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
@@ -118,11 +118,11 @@ export async function GET(request: NextRequest) {
       console.error('GitHub access token not found in response:', tokenData);
       throw new Error('Access token not found in GitHub response.');
     }
-    console.log('GitHub access token obtained successfully.');
+    console.error('GitHub access token obtained successfully.');
     // --- End Token Exchange ---
 
     // --- 4. Fetch GitHub User Info ---
-    console.log('Fetching GitHub user information...');
+    console.error('Fetching GitHub user information...');
     const userResponse = await fetch('https://api.github.com/user', {
       headers: { Authorization: `Bearer ${accessToken}`, Accept: 'application/vnd.github.v3+json' },
     });
@@ -140,11 +140,11 @@ export async function GET(request: NextRequest) {
     }
 
     const githubUser = await userResponse.json();
-    console.log(`GitHub user info fetched: ${githubUser.login} (ID: ${githubUser.id})`);
+    console.error(`GitHub user info fetched: ${githubUser.login} (ID: ${githubUser.id})`);
     // --- End User Info Fetch ---
 
     // --- 5. Store Integration Details via Backend API ---
-    console.log('Storing GitHub integration details via backend API...');
+    console.error('Storing GitHub integration details via backend API...');
     const apiHeaders = new Headers({ 'Content-Type': 'application/json' });
     const cookieStore = await cookies(); // Keep await based on previous fixes
     const authTokenCookie = cookieStore.get('auth_token'); // Ensure this is the correct cookie name
@@ -184,7 +184,7 @@ export async function GET(request: NextRequest) {
     }
 
     const storeResult = await storeIntegrationResponse.json();
-    console.log('GitHub integration stored successfully via backend API:', storeResult);
+    console.error('GitHub integration stored successfully via backend API');
     // --- End Integration Storage ---
 
     // --- 6. Redirect User Back to Frontend (Success) ---
@@ -192,7 +192,7 @@ export async function GET(request: NextRequest) {
     finalRedirectUrl.searchParams.set('oauth_callback', 'true');
     finalRedirectUrl.searchParams.set('platform', 'github');
     finalRedirectUrl.searchParams.set('status', 'success');
-    console.log(`Redirecting user to success URL: ${finalRedirectUrl.toString()}`);
+    console.error(`Redirecting user to success URL: ${finalRedirectUrl.toString()}`);
     return NextResponse.redirect(finalRedirectUrl.toString(), { status: 302 });
   } catch (error) {
     // --- Error Handling & Redirect (Failure) ---
@@ -207,7 +207,7 @@ export async function GET(request: NextRequest) {
         ? error.message
         : 'An unknown error occurred during GitHub connection.';
     errorRedirectUrl.searchParams.set('error_message', errorMessage);
-    console.log(`Redirecting user to error URL: ${errorRedirectUrl.toString()}`);
+    console.error(`Redirecting user to error URL: ${errorRedirectUrl.toString()}`);
     return NextResponse.redirect(errorRedirectUrl.toString(), { status: 302 });
   }
 }

--- a/ui/src/app/api/settings/integrations/github/connect/route.ts
+++ b/ui/src/app/api/settings/integrations/github/connect/route.ts
@@ -53,7 +53,7 @@ export async function GET(request: NextRequest) {
   // Example (conceptual, requires cookie library/helper):
   // const stateCookieOptions = { httpOnly: true, secure: true, path: '/', maxAge: 300 }; // 5 minutes
   // cookies().set('github_oauth_state', stateValue, stateCookieOptions);
-  console.log(`Generated state for GitHub OAuth: ${stateValue} (Storage TODO)`);
+  console.error('Generated state for GitHub OAuth (Storage TODO)');
   // --- End State Generation ---
 
   // Get the desired final redirect path from the client request
@@ -72,7 +72,7 @@ export async function GET(request: NextRequest) {
   // Optional: add allow_signup=false if you don't want users creating new GitHub accounts during flow
   // authUrl.searchParams.set('allow_signup', 'false');
 
-  console.log(`Redirecting user to GitHub for authorization: ${authUrl.toString()}`);
+  console.error(`Redirecting user to GitHub for authorization: ${authUrl.toString()}`);
 
   // Redirect the user to GitHub
   return NextResponse.redirect(authUrl.toString(), { status: 302 });

--- a/ui/src/app/api/settings/integrations/github/disconnect/route.ts
+++ b/ui/src/app/api/settings/integrations/github/disconnect/route.ts
@@ -20,7 +20,7 @@ import { updateMockIntegrationStatus } from '@/lib/integration-mock-db'; // Mock
  */
 export async function POST(req: NextRequest) {
   // Add req parameter
-  console.warn(
+  console.error(
     '⚠️ Using MOCK /api/settings/integrations/github/disconnect endpoint! Replace with actual implementation. ⚠️',
   );
   try {
@@ -33,7 +33,7 @@ export async function POST(req: NextRequest) {
     // }
     // const userId = authResult.userId;
     const userId = 'default-user'; // Hardcoded mock user ID
-    console.log(`Processing disconnect request for GitHub for user: ${userId}`);
+    console.error(`Processing disconnect request for GitHub for user: ${userId}`);
     // --- !!! MOCK AUTHENTICATION END !!! ---
 
     // --- !!! MOCK DISCONNECT LOGIC START !!! ---
@@ -54,7 +54,7 @@ export async function POST(req: NextRequest) {
     // --- !!! MOCK DISCONNECT LOGIC END !!! ---
 
     if (success) {
-      console.log(`Mock disconnect successful for GitHub for user: ${userId}`);
+      console.error(`Mock disconnect successful for GitHub for user: ${userId}`);
       return NextResponse.json({
         success: true,
         message: 'GitHub account disconnected successfully.',

--- a/ui/src/app/api/settings/integrations/notion/callback/route.ts
+++ b/ui/src/app/api/settings/integrations/notion/callback/route.ts
@@ -68,7 +68,7 @@ export async function GET(request: NextRequest) {
 
   // --- 3. State Verification (CSRF Protection - Simplified) ---
   // !!! SECURITY TODO: Implement proper state verification (see GitHub callback comments) !!!
-  console.log(
+  console.error(
     `Notion callback state received. Extracted redirect path: ${clientFinalRedirectPath}`,
   );
   // --- End State Verification ---
@@ -106,7 +106,7 @@ export async function GET(request: NextRequest) {
 
   try {
     // --- 4. Exchange Code for Access Token ---
-    console.log('Exchanging Notion code for access token...');
+    console.error('Exchanging Notion code for access token...');
     const tokenResponse = await fetch('https://api.notion.com/v1/oauth/token', {
       method: 'POST',
       headers: {
@@ -142,11 +142,11 @@ export async function GET(request: NextRequest) {
       console.error('Notion access token or workspace_id not found in response:', tokenData);
       throw new Error('Access token or workspace_id not found in Notion response.');
     }
-    console.log(`Notion access token obtained successfully for workspace: ${workspaceId}`);
+    console.error(`Notion access token obtained successfully for workspace: ${workspaceId}`);
     // --- End Token Exchange ---
 
     // --- 5. Store Integration Details via Backend API ---
-    console.log('Storing Notion integration details via backend API...');
+    console.error('Storing Notion integration details via backend API...');
     const apiHeaders = new Headers({ 'Content-Type': 'application/json' });
     const cookieStore = await cookies(); // Keep await
     const authTokenCookie = cookieStore.get('auth_token'); // Ensure correct cookie name
@@ -189,7 +189,7 @@ export async function GET(request: NextRequest) {
     }
 
     const storeResult = await storeIntegrationResponse.json();
-    console.log('Notion integration stored successfully via backend API:', storeResult);
+    console.error('Notion integration stored successfully via backend API');
     // --- End Integration Storage ---
 
     // --- 6. Redirect User Back to Frontend (Success) ---
@@ -197,7 +197,7 @@ export async function GET(request: NextRequest) {
     finalRedirectUrl.searchParams.set('oauth_callback', 'true');
     finalRedirectUrl.searchParams.set('platform', 'notion');
     finalRedirectUrl.searchParams.set('status', 'success');
-    console.log(`Redirecting user to success URL: ${finalRedirectUrl.toString()}`);
+    console.error(`Redirecting user to success URL: ${finalRedirectUrl.toString()}`);
     return NextResponse.redirect(finalRedirectUrl.toString(), { status: 302 });
   } catch (error) {
     // --- Error Handling & Redirect (Failure) ---
@@ -211,7 +211,7 @@ export async function GET(request: NextRequest) {
         ? error.message
         : 'An unknown error occurred during Notion connection.';
     errorRedirectUrl.searchParams.set('error_message', errorMessage);
-    console.log(`Redirecting user to error URL: ${errorRedirectUrl.toString()}`);
+    console.error(`Redirecting user to error URL: ${errorRedirectUrl.toString()}`);
     return NextResponse.redirect(errorRedirectUrl.toString(), { status: 302 });
   }
 }

--- a/ui/src/app/api/settings/integrations/notion/connect/route.ts
+++ b/ui/src/app/api/settings/integrations/notion/connect/route.ts
@@ -48,7 +48,7 @@ export async function GET(request: NextRequest) {
   // --- State Generation (CSRF Protection) ---
   const stateValue = uuidv4();
   // !!! SECURITY TODO: Store `stateValue` securely (e.g., HttpOnly cookie with short expiry) !!!
-  console.log(`Generated state for Notion OAuth: ${stateValue} (Storage TODO)`);
+  console.error('Generated state for Notion OAuth (Storage TODO)');
   // --- End State Generation ---
 
   // Get the desired final redirect path from the client request
@@ -66,7 +66,7 @@ export async function GET(request: NextRequest) {
   authUrl.searchParams.set('owner', 'user'); // Required by Notion
   authUrl.searchParams.set('state', combinedState);
 
-  console.log(`Redirecting user to Notion for authorization: ${authUrl.toString()}`);
+  console.error(`Redirecting user to Notion for authorization: ${authUrl.toString()}`);
 
   // Redirect the user to Notion
   return NextResponse.redirect(authUrl.toString(), { status: 302 });

--- a/ui/src/app/api/settings/integrations/notion/disconnect/route.ts
+++ b/ui/src/app/api/settings/integrations/notion/disconnect/route.ts
@@ -22,7 +22,7 @@ import { updateMockIntegrationStatus } from '@/lib/integration-mock-db'; // Mock
  */
 export async function POST(req: NextRequest) {
   // Add req parameter
-  console.warn(
+  console.error(
     '⚠️ Using MOCK /api/settings/integrations/notion/disconnect endpoint! Replace with actual implementation. ⚠️',
   );
   try {
@@ -35,7 +35,7 @@ export async function POST(req: NextRequest) {
     // }
     // const userId = authResult.userId;
     const userId = 'default-user'; // Hardcoded mock user ID
-    console.log(`Processing disconnect request for Notion for user: ${userId}`);
+    console.error(`Processing disconnect request for Notion for user: ${userId}`);
     // --- !!! MOCK AUTHENTICATION END !!! ---
 
     // --- !!! MOCK DISCONNECT LOGIC START !!! ---
@@ -54,7 +54,7 @@ export async function POST(req: NextRequest) {
     // --- !!! MOCK DISCONNECT LOGIC END !!! ---
 
     if (success) {
-      console.log(`Mock disconnect successful for Notion for user: ${userId}`);
+      console.error(`Mock disconnect successful for Notion for user: ${userId}`);
       return NextResponse.json({
         success: true,
         message: 'Notion account disconnected successfully.',

--- a/ui/src/app/api/settings/integrations/route.ts
+++ b/ui/src/app/api/settings/integrations/route.ts
@@ -18,7 +18,7 @@ import { getMockIntegrationStatuses } from '@/lib/integration-mock-db'; // Mock 
  */
 export async function GET(req: NextRequest) {
   // Add req parameter
-  console.warn(
+  console.error(
     '⚠️ Using MOCK /api/settings/integrations endpoint! Replace with actual implementation. ⚠️',
   );
   try {
@@ -31,7 +31,7 @@ export async function GET(req: NextRequest) {
     // }
     // const userId = authResult.userId;
     const userId = 'default-user'; // Hardcoded mock user ID
-    console.log(`Fetching mock integration statuses for user: ${userId}`);
+    console.error(`Fetching mock integration statuses for user: ${userId}`);
     // --- !!! MOCK AUTHENTICATION END !!! ---
 
     // Fetch statuses from the mock data source


### PR DESCRIPTION
## Summary
- remove `console.log`/`console.warn` usage in server routes
- use `console.error` for mock and status messages to avoid `console.log`

## Testing
- `just lint`
- `just test`
- `just build`
