### PR TITLE
Serialize DLQ messages in Constellation

### DIFF
--- a/services/constellation/tests/sendToDeadLetter.test.ts
+++ b/services/constellation/tests/sendToDeadLetter.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('cloudflare:workers', () => ({
+  WorkerEntrypoint: class { constructor(_c: any, public env: any) {} }
+}));
+
+vi.mock('../src/utils/logging', () => ({
+  getLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  logError: vi.fn(),
+  trackOperation: async (_n: string, fn: () => Promise<any>) => fn(),
+  constellationMetrics: {
+    counter: vi.fn(),
+    gauge: vi.fn(),
+    timing: vi.fn(),
+    startTimer: () => ({ stop: vi.fn() }),
+  },
+}));
+
+vi.mock('../src/utils/errors', () => ({
+  toDomeError: (e: any) => e,
+}));
+
+vi.mock('@dome/errors', () => ({}));
+
+import { sendToDeadLetter } from '../src';
+
+describe('sendToDeadLetter', () => {
+  it('sends a serialized message', async () => {
+    const queue = { send: vi.fn() } as any;
+    const payload = { error: 'oops', originalMessage: { id: 1 } } as any;
+    await sendToDeadLetter(queue, payload, 'req1');
+    expect(queue.send).toHaveBeenCalledTimes(1);
+    const arg = queue.send.mock.calls[0][0];
+    expect(typeof arg).toBe('string');
+    expect(() => JSON.parse(arg)).not.toThrow();
+  });
+
+  it('throws for invalid payload', async () => {
+    const queue = { send: vi.fn() } as any;
+    const badPayload = { foo: 'bar' } as any;
+    await expect(sendToDeadLetter(queue, badPayload, 'req2')).rejects.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- pass EmbedDeadLetter messages through `serializeQueueMessage`
- expose `sendToDeadLetter` for testing
- add unit tests verifying serialization and invalid payload handling

## Testing
- `pnpm -r test`
- `pnpm run lint`
- `pnpm run build`
