### PR TITLE
Fix chat wrapping and settings scrolling

### DIFF
--- a/ui/src/components/chat/AssistantMessage.tsx
+++ b/ui/src/components/chat/AssistantMessage.tsx
@@ -127,7 +127,7 @@ const ErrorDisplay: React.FC<ErrorDisplayProps> = ({ errorData, userFriendlyText
         <span className="font-semibold text-sm">Error</span>
         {errorData.code && <Badge variant="destructive" className="ml-2 text-xs">{errorData.code}</Badge>}
       </div>
-      <p className="text-destructive text-xs prose prose-sm dark:prose-invert max-w-none">
+      <p className="text-destructive text-xs prose prose-sm dark:prose-invert max-w-none break-words">
         {userFriendlyText || errorData.message}
       </p>
       {userFriendlyText && errorData.message !== userFriendlyText && (
@@ -176,7 +176,7 @@ export const AssistantMessage: React.FC<AssistantMessageProps> = ({ message }) =
     case 'content':
       contentToRender = (
         <div className="space-y-3">
-          <div className="prose prose-sm dark:prose-invert max-w-none">
+          <div className="prose prose-sm dark:prose-invert max-w-none break-words">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{message.text}</ReactMarkdown>
           </div>
           {/*

--- a/ui/src/components/chat/ChatMessage.tsx
+++ b/ui/src/components/chat/ChatMessage.tsx
@@ -66,7 +66,7 @@ export const ChatMessage: React.FC<ChatMessageProps> = ({
         ) : (
           // Only render message.text if it exists on the message type
           // UserMessage has text. For others, contentOverride should be used.
-          <p className="text-sm leading-relaxed whitespace-pre-wrap">
+          <p className="text-sm leading-relaxed whitespace-pre-wrap break-words">
             {('text' in message && typeof message.text === 'string') ? message.text : ''}
           </p>
         )}

--- a/ui/src/components/layout/LayoutWithSidebar.tsx
+++ b/ui/src/components/layout/LayoutWithSidebar.tsx
@@ -38,7 +38,7 @@ export function LayoutWithSidebar({ children }: LayoutWithSidebarProps) {
   }
 
   return (
-    <div className="flex h-screen flex-col"> {/* Changed to flex-col for header on top */}
+    <div className="flex min-h-screen flex-col"> {/* Changed to min-h-screen to allow page scroll */}
       <Header /> {/* Add the new Header component here */}
       <div className="flex flex-1 overflow-hidden"> {/* Container for sidebar and main content */}
         {/* Desktop Sidebar */}


### PR DESCRIPTION
## Summary
- ensure chat message text wraps on narrow screens
- allow overflowing pages like Settings to scroll

## Testing
- `just lint`
- `just build`
- `just test`
