### PR TITLE
Add helper for queue batch conversion

### DIFF
--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -76,6 +76,7 @@ Helpers for validating and converting queue messages between services:
 - `serializeQueueMessage(schema, message)`: validate and stringify a message.
 - `parseQueueMessage(schema, body)`: parse and validate a JSON message body.
 - `parseMessageBatch(schema, batch)`: convert a batch of raw messages into typed objects.
+- `toRawMessageBatch(batch)`: normalize a Cloudflare `MessageBatch` to the raw format.
 
 ## Migration Guide
 

--- a/packages/common/tests/queue.test.ts
+++ b/packages/common/tests/queue.test.ts
@@ -5,6 +5,7 @@ import {
   parseMessageBatch,
   serializeQueueMessage,
   RawMessageBatch,
+  toRawMessageBatch,
 } from '../src/queue';
 import { MessageProcessingError } from '../src/errors/ServiceError';
 
@@ -66,5 +67,26 @@ describe('queue message helpers', () => {
     expect(() => parseMessageBatch(NewContentMessageSchema, batch)).toThrow(
       MessageProcessingError
     );
+  });
+
+  it('converts a MessageBatch to raw format', () => {
+    const msg = {
+      id: 'a',
+      timestamp: new Date(1),
+      body: JSON.stringify(validMessage),
+      attempts: 0,
+      retry() {},
+      ack() {},
+    };
+    const batch: MessageBatch<string> = {
+      queue: 'test',
+      messages: [msg],
+      retryAll() {},
+      ackAll() {},
+    };
+
+    const raw = toRawMessageBatch(batch);
+    expect(raw.messages[0].timestamp).toBe(1);
+    expect(raw.messages[0].body).toBe(msg.body);
   });
 });

--- a/services/ai-processor/src/index.ts
+++ b/services/ai-processor/src/index.ts
@@ -16,7 +16,7 @@ import {
   NewContentMessageSchema,
   parseMessageBatch,
   ParsedMessageBatch,
-  RawMessageBatch,
+  toRawMessageBatch,
 } from '@dome/common';
 import { SiloClient, SiloBinding } from '@dome/silo/client';
 import type { ServiceEnv } from './types';
@@ -354,7 +354,10 @@ export default class AiProcessor extends WorkerEntrypoint<ServiceEnv> {
 
         let parsed: ParsedMessageBatch<NewContentMessage>;
         try {
-          parsed = parseMessageBatch(NewContentMessageSchema, batch as unknown as RawMessageBatch);
+          parsed = parseMessageBatch(
+            NewContentMessageSchema,
+            toRawMessageBatch(batch),
+          );
         } catch (err) {
           const domeError = toDomeError(err, 'Failed to parse message batch', {
             batchId,

--- a/services/constellation/src/index.ts
+++ b/services/constellation/src/index.ts
@@ -7,7 +7,7 @@ import {
   parseMessageBatch,
   ParsedMessageBatch,
   ParsedQueueMessage,
-  RawMessageBatch,
+  toRawMessageBatch,
   NewContentMessage,
   SiloContentItem,
   serializeQueueMessage,
@@ -499,7 +499,7 @@ export default class Constellation extends WorkerEntrypoint<ServiceEnv> {
         try {
           parsed = parseMessageBatch(
             NewContentMessageSchema,
-            batch as unknown as RawMessageBatch,
+            toRawMessageBatch(batch),
           );
         } catch (err) {
           const domeError = toDomeError(err, 'Failed to parse message batch', {

--- a/services/constellation/tests/queue.integration.test.ts
+++ b/services/constellation/tests/queue.integration.test.ts
@@ -13,6 +13,7 @@ vi.mock('@dome/common', () => ({
     })),
   }),
   NewContentMessageSchema: {},
+  toRawMessageBatch: (b: any) => b,
 }));
 vi.mock('@dome/errors', () => ({}));
 vi.mock('../src/utils/errors', () => ({

--- a/services/todos/src/queueConsumer.ts
+++ b/services/todos/src/queueConsumer.ts
@@ -1,6 +1,12 @@
 import { Env, TodoJob, TodoQueueItemSchema, TodoQueueItem } from './types';
 import { TodosService } from './services/todosService';
-import { getLogger, logError, parseMessageBatch, RawMessageBatch, ParsedMessageBatch } from '@dome/common';
+import {
+  getLogger,
+  logError,
+  parseMessageBatch,
+  ParsedMessageBatch,
+  toRawMessageBatch,
+} from '@dome/common';
 import { AiProcessorAdapter } from './adapters/aiProcessorAdapter';
 
 const logger = getLogger();
@@ -29,15 +35,10 @@ export async function processTodoQueue(
   // Convert the incoming batch to typed queue items
   let parsed: ParsedMessageBatch<TodoQueueItem>;
   try {
-    const rawBatch: RawMessageBatch = {
-      queue: batch.queue,
-      messages: batch.messages.map(m => ({
-        id: m.id,
-        timestamp: typeof m.timestamp === 'number' ? m.timestamp : m.timestamp.getTime(),
-        body: typeof m.body === 'string' ? m.body : JSON.stringify(m.body),
-      })),
-    };
-    parsed = parseMessageBatch(TodoQueueItemSchema, rawBatch);
+    parsed = parseMessageBatch(
+      TodoQueueItemSchema,
+      toRawMessageBatch(batch),
+    );
   } catch (error) {
     logError(error, 'Failed to parse todo queue batch');
     return;


### PR DESCRIPTION
## Summary
- implement `toRawMessageBatch` in `@dome/common`
- use the new helper in Ai Processor, Constellation and Todos services
- update Constellation tests to mock the helper
- document the helper and add unit tests

## Testing
- `just lint`
- `just build`
- `just test`
