### PR TITLE
Add NewContentQueue and adjust AbstractQueue

### DIFF
--- a/packages/common/src/queue/AbstractQueue.test.ts
+++ b/packages/common/src/queue/AbstractQueue.test.ts
@@ -14,7 +14,7 @@ type TestMessage = z.infer<typeof TestMessageSchema>;
 
 // Concrete implementation for testing
 class TestQueue extends AbstractQueue<TestMessage, typeof TestMessageSchema> {
-  protected readonly schema = TestMessageSchema;
+  public static schema = TestMessageSchema;
 }
 
 // Mock queue

--- a/services/constellation/src/index.ts
+++ b/services/constellation/src/index.ts
@@ -2,11 +2,8 @@ import { WorkerEntrypoint } from 'cloudflare:workers';
 import {
   VectorMeta,
   VectorSearchResult,
-  NewContentMessageSchema,
-  parseMessageBatch,
-  ParsedMessageBatch,
   ParsedQueueMessage,
-  toRawMessageBatch,
+  ParsedMessageBatch,
   NewContentMessage,
   SiloContentItem,
 } from '@dome/common';
@@ -31,6 +28,7 @@ import { createVectorizeService } from './services/vectorize';
 import { SiloClient, SiloBinding } from '@dome/silo/client';
 import { Queue } from '@cloudflare/workers-types/experimental';
 import { DeadLetterQueue } from './queues/DeadLetterQueue';
+import { NewContentQueue } from './queues/NewContentQueue';
 
 interface ServiceEnv extends Omit<Cloudflare.Env, 'SILO'> {
   SILO: SiloBinding;
@@ -506,10 +504,7 @@ export default class Constellation extends WorkerEntrypoint<ServiceEnv> {
 
         let parsed: ParsedMessageBatch<NewContentMessage>;
         try {
-          parsed = parseMessageBatch(
-            NewContentMessageSchema,
-            toRawMessageBatch(batch),
-          );
+          parsed = NewContentQueue.parseBatch(batch);
         } catch (err) {
           const domeError = toDomeError(err, 'Failed to parse message batch', {
             batchId,

--- a/services/constellation/src/queues/DeadLetterQueue.ts
+++ b/services/constellation/src/queues/DeadLetterQueue.ts
@@ -12,5 +12,5 @@ export type DeadLetterMessage = z.infer<typeof EmbedDeadLetterMessageSchema>;
  * Uses the existing EmbedDeadLetterMessageSchema from common.
  */
 export class DeadLetterQueue extends AbstractQueue<DeadLetterMessage, typeof EmbedDeadLetterMessageSchema> {
-  protected readonly schema = EmbedDeadLetterMessageSchema;
-} 
+  public static schema = EmbedDeadLetterMessageSchema;
+}

--- a/services/constellation/src/queues/NewContentQueue.ts
+++ b/services/constellation/src/queues/NewContentQueue.ts
@@ -1,0 +1,8 @@
+import { AbstractQueue } from '@dome/common/queue';
+import { NewContentMessage, NewContentMessageSchema } from '@dome/common';
+
+export type { NewContentMessage };
+
+export class NewContentQueue extends AbstractQueue<NewContentMessage, typeof NewContentMessageSchema> {
+  public static schema = NewContentMessageSchema;
+}

--- a/services/constellation/tests/newContentQueue.test.ts
+++ b/services/constellation/tests/newContentQueue.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NewContentQueue } from '../src/queues/NewContentQueue';
+import { NewContentMessageSchema } from '@dome/common';
+import * as queueHelpers from '@dome/common/queue';
+
+const mockQueue = { send: vi.fn() };
+
+const validMessage = { id: '1', userId: 'u' };
+
+describe('NewContentQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('serializes messages using the schema', async () => {
+    const queue = new NewContentQueue(mockQueue as any);
+    const spy = vi.spyOn(queueHelpers, 'serializeQueueMessage');
+    await queue.send(validMessage);
+    expect(spy).toHaveBeenCalledWith(NewContentMessageSchema, validMessage);
+    expect(mockQueue.send).toHaveBeenCalledTimes(1);
+  });
+
+  it('parses a batch', () => {
+    const batch: queueHelpers.MessageBatch<string> = {
+      queue: 'test',
+      messages: [
+        {
+          id: 'a',
+          timestamp: new Date(1),
+          body: JSON.stringify(validMessage),
+        },
+      ],
+    };
+
+    const parsed = NewContentQueue.parseBatch(batch);
+    expect(parsed.messages[0].body).toEqual(validMessage);
+  });
+});

--- a/services/constellation/tests/queue.integration.test.ts
+++ b/services/constellation/tests/queue.integration.test.ts
@@ -1,19 +1,26 @@
 import { describe, it, expect, vi } from 'vitest';
 vi.mock('cloudflare:workers', () => ({ WorkerEntrypoint: class { env: any; constructor(_c: any, env: any) { this.env = env; } } }));
-vi.mock('@dome/common', () => ({
-  getLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
-  PUBLIC_USER_ID: 'public',
-  withContext: async (_m: any, fn: any) => fn({}),
-  parseMessageBatch: (_schema: any, batch: any) => ({
-    queue: batch.queue,
-    messages: batch.messages.map((m: any) => ({
-      id: m.id,
-      timestamp: m.timestamp,
-      body: { id: m.id, userId: 'u', category: 'cat', mimeType: 'text', createdAt: Date.now() },
-    })),
-  }),
-  NewContentMessageSchema: {},
-  toRawMessageBatch: (b: any) => b,
+vi.mock('@dome/common', async () => {
+  const actual = await vi.importActual<any>('@dome/common');
+  return {
+    ...actual,
+    getLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+    PUBLIC_USER_ID: 'public',
+    withContext: async (_m: any, fn: any) => fn({}),
+  };
+});
+
+vi.mock('../src/queues/NewContentQueue', () => ({
+  NewContentQueue: {
+    parseBatch: (batch: any) => ({
+      queue: batch.queue,
+      messages: batch.messages.map((m: any) => ({
+        id: m.id,
+        timestamp: m.timestamp,
+        body: { id: m.id, userId: 'u', category: 'cat', mimeType: 'text', createdAt: Date.now() },
+      })),
+    }),
+  },
 }));
 vi.mock('@dome/errors', () => ({}));
 vi.mock('../src/utils/errors', () => ({

--- a/services/constellation/tests/sendToDeadLetter.test.ts
+++ b/services/constellation/tests/sendToDeadLetter.test.ts
@@ -20,6 +20,11 @@ vi.mock('../src/utils/errors', () => ({
   toDomeError: (e: any) => e,
 }));
 
+vi.mock('@dome/common', async () => {
+  const actual = await vi.importActual<any>('@dome/common');
+  return { ...actual };
+});
+
 vi.mock('@dome/errors', () => ({}));
 
 import { sendToDeadLetter } from '../src';


### PR DESCRIPTION
## Summary
- refactor `AbstractQueue` to store schemas on the class so static helpers work
- implement `NewContentQueue` for constellation
- use `NewContentQueue.parseBatch` in constellation worker
- update queue tests and mocks

## Testing
- `just build`
- `just test`
- `just lint`