### PR TITLE
Improve AbstractQueue with batch sends

### DIFF
--- a/packages/common/src/queue/AbstractQueue.test.ts
+++ b/packages/common/src/queue/AbstractQueue.test.ts
@@ -13,13 +13,14 @@ const TestMessageSchema = z.object({
 type TestMessage = z.infer<typeof TestMessageSchema>;
 
 // Concrete implementation for testing
-class TestQueue extends AbstractQueue<TestMessage, typeof TestMessageSchema> {
-  public static schema = TestMessageSchema;
+class TestQueue extends AbstractQueue<typeof TestMessageSchema> {
+  static override schema = TestMessageSchema;
 }
 
 // Mock queue
 const mockQueue = {
   send: vi.fn().mockResolvedValue(undefined),
+  sendBatch: vi.fn().mockResolvedValue(undefined),
 };
 
 // Sample valid message
@@ -57,9 +58,9 @@ describe('AbstractQueue', () => {
     ];
     
     await queue.sendBatch(messages);
-    
-    // Verify queue.send was called for each message
-    expect(mockQueue.send).toHaveBeenCalledTimes(3);
+
+    // Should use sendBatch once with all messages
+    expect(mockQueue.sendBatch).toHaveBeenCalledTimes(1);
   });
 
   test('parseBatch() should delegate to helpers with schema', () => {
@@ -67,7 +68,7 @@ describe('AbstractQueue', () => {
     // test that the helper methods would be called correctly
     
     // Create a mock message batch to verify serialization behavior
-    const mockQueue = new TestQueue({ send: vi.fn() });
+    const mockQueue = new TestQueue({ send: vi.fn(), sendBatch: vi.fn() } as any);
     const mockMessage: TestMessage = { id: 'test', value: 123 };
     
     // Spy on the core functions we expect to be used

--- a/packages/common/src/queue/README.md
+++ b/packages/common/src/queue/README.md
@@ -23,8 +23,8 @@ export const ContentMessageSchema = z.object({
 export type ContentMessage = z.infer<typeof ContentMessageSchema>;
 
 // 3. Create a queue wrapper subclass
-export class ContentQueue extends AbstractQueue<ContentMessage, typeof ContentMessageSchema> {
-  protected readonly schema = ContentMessageSchema;
+export class ContentQueue extends AbstractQueue<typeof ContentMessageSchema> {
+  static override schema = ContentMessageSchema;
 }
 ```
 

--- a/services/constellation/src/queues/DeadLetterQueue.ts
+++ b/services/constellation/src/queues/DeadLetterQueue.ts
@@ -11,6 +11,6 @@ export type DeadLetterMessage = z.infer<typeof EmbedDeadLetterMessageSchema>;
  * Type-safe wrapper for the dead letter queue.
  * Uses the existing EmbedDeadLetterMessageSchema from common.
  */
-export class DeadLetterQueue extends AbstractQueue<DeadLetterMessage, typeof EmbedDeadLetterMessageSchema> {
-  public static schema = EmbedDeadLetterMessageSchema;
+export class DeadLetterQueue extends AbstractQueue<typeof EmbedDeadLetterMessageSchema> {
+  static override schema = EmbedDeadLetterMessageSchema;
 }

--- a/services/constellation/src/queues/NewContentQueue.ts
+++ b/services/constellation/src/queues/NewContentQueue.ts
@@ -3,6 +3,6 @@ import { NewContentMessage, NewContentMessageSchema } from '@dome/common';
 
 export type { NewContentMessage };
 
-export class NewContentQueue extends AbstractQueue<NewContentMessage, typeof NewContentMessageSchema> {
-  public static schema = NewContentMessageSchema;
+export class NewContentQueue extends AbstractQueue<typeof NewContentMessageSchema> {
+  static override schema = NewContentMessageSchema;
 }

--- a/services/constellation/tests/newContentQueue.test.ts
+++ b/services/constellation/tests/newContentQueue.test.ts
@@ -3,7 +3,7 @@ import { NewContentQueue } from '../src/queues/NewContentQueue';
 import { NewContentMessageSchema } from '@dome/common';
 import * as queueHelpers from '@dome/common/queue';
 
-const mockQueue = { send: vi.fn() };
+const mockQueue = { send: vi.fn(), sendBatch: vi.fn() };
 
 const validMessage = { id: '1', userId: 'u' };
 


### PR DESCRIPTION
## Summary
- streamline queue wrapper generics
- add support for `Queue.sendBatch`
- update README and tests
- adjust constellation queues to new API

## Testing
- `just build-pkg common`
- `just lint-pkg common`
- `just test-pkg common`
- `just test-pkg constellation`
- `just lint`
- `just test`
