### PR TITLE
Improve AbstractQueue with batch sends

### DIFF
--- a/packages/common/src/queue/AbstractQueue.test.ts
+++ b/packages/common/src/queue/AbstractQueue.test.ts
@@ -13,13 +13,14 @@ const TestMessageSchema = z.object({
 type TestMessage = z.infer<typeof TestMessageSchema>;
 
 // Concrete implementation for testing
-class TestQueue extends AbstractQueue<TestMessage, typeof TestMessageSchema> {
-  public static schema = TestMessageSchema;
+class TestQueue extends AbstractQueue<typeof TestMessageSchema> {
+  static override schema = TestMessageSchema;
 }
 
 // Mock queue
 const mockQueue = {
   send: vi.fn().mockResolvedValue(undefined),
+  sendBatch: vi.fn().mockResolvedValue(undefined),
 };
 
 // Sample valid message
@@ -57,9 +58,9 @@ describe('AbstractQueue', () => {
     ];
     
     await queue.sendBatch(messages);
-    
-    // Verify queue.send was called for each message
-    expect(mockQueue.send).toHaveBeenCalledTimes(3);
+
+    // Should use sendBatch once with all messages
+    expect(mockQueue.sendBatch).toHaveBeenCalledTimes(1);
   });
 
   test('parseBatch() should delegate to helpers with schema', () => {
@@ -67,7 +68,7 @@ describe('AbstractQueue', () => {
     // test that the helper methods would be called correctly
     
     // Create a mock message batch to verify serialization behavior
-    const mockQueue = new TestQueue({ send: vi.fn() });
+    const mockQueue = new TestQueue({ send: vi.fn(), sendBatch: vi.fn() } as any);
     const mockMessage: TestMessage = { id: 'test', value: 123 };
     
     // Spy on the core functions we expect to be used

--- a/packages/common/src/queue/AbstractQueue.ts
+++ b/packages/common/src/queue/AbstractQueue.ts
@@ -1,4 +1,4 @@
-import { z, ZodSchema } from 'zod';
+import { z, type ZodTypeAny } from 'zod';
 import {
   serializeQueueMessage,
   parseMessageBatch,
@@ -8,14 +8,20 @@ import {
   MessageBatch,
 } from './index.js';
 
+/** Minimal subset of the Cloudflare Queue interface used by this helper */
+export interface Queue {
+  send(body: string | ArrayBuffer): Promise<void>;
+  sendBatch(messages: Iterable<{ body: string | ArrayBuffer }>): Promise<void>;
+}
+
 /**
  * Abstract base class for type-safe queue wrappers.
  * Subclasses must provide a Zod schema to validate and serialize messages.
  * 
  * @example
  * ```ts
- * export class ContentQueue extends AbstractQueue<ContentMessage, typeof ContentMessageSchema> {
- *   protected readonly schema = ContentMessageSchema;
+ * export class ContentQueue extends AbstractQueue<typeof ContentMessageSchema> {
+ *   static override schema = ContentMessageSchema;
  * }
  * 
  * // Producer
@@ -26,26 +32,32 @@ import {
  * const messages = ContentQueue.parseBatch(batch);
  * ```
  */
-export abstract class AbstractQueue<T, S extends ZodSchema<T>> {
+type MessageOf<S extends ZodTypeAny> = z.infer<S>;
+
+export abstract class AbstractQueue<S extends ZodTypeAny> {
   /**
    * The Zod schema used to validate and serialize messages.
    * Subclasses must provide this as a static field.
    */
-  public static schema: ZodSchema<any>;
+  static schema: ZodTypeAny;
 
   /**
    * Create a new queue wrapper for the given Cloudflare Queue binding.
    * @param queue The Cloudflare Queue binding
    */
-  constructor(protected readonly queue: { send(body: string | ArrayBuffer): Promise<void> }) {}
+  protected readonly schema: S;
+
+  constructor(protected readonly queue: Queue) {
+    // Bridge the static schema to the instance for convenience
+    this.schema = (this.constructor as typeof AbstractQueue & { schema: S }).schema as S;
+  }
 
   /**
    * Send a validated message to the queue.
    * @param message The message to send
    */
-  async send(message: T): Promise<void> {
-    const cls = this.constructor as typeof AbstractQueue & { schema: S };
-    const serialized = serializeQueueMessage(cls.schema as S, message);
+  async send(message: MessageOf<S>): Promise<void> {
+    const serialized = serializeQueueMessage(this.schema, message);
     await this.queue.send(serialized);
   }
 
@@ -53,10 +65,11 @@ export abstract class AbstractQueue<T, S extends ZodSchema<T>> {
    * Send multiple messages to the queue in sequence.
    * @param messages The messages to send
    */
-  async sendBatch(messages: Iterable<T>): Promise<void> {
-    for (const message of messages) {
-      await this.send(message);
-    }
+  async sendBatch(messages: ReadonlyArray<MessageOf<S>>): Promise<void> {
+    const payload = messages.map(m => ({
+      body: serializeQueueMessage(this.schema, m),
+    }));
+    await this.queue.sendBatch(payload);
   }
 
   /**
@@ -66,11 +79,11 @@ export abstract class AbstractQueue<T, S extends ZodSchema<T>> {
    * @param batch The raw message batch from Cloudflare
    * @returns The parsed messages with proper types
    */
-  static parseBatch<T, S extends ZodSchema<T>>(
-    this: { new (...args: any[]): AbstractQueue<T, S> } & { schema: S },
+  static parseBatch<S extends ZodTypeAny>(
+    this: { schema: S },
     batch: MessageBatch<unknown>
-  ): ParsedMessageBatch<T> {
+  ): ParsedMessageBatch<MessageOf<S>> {
     const raw = toRawMessageBatch(batch);
-    return parseMessageBatch(this.schema as S, raw as RawMessageBatch);
+    return parseMessageBatch(this.schema, raw as RawMessageBatch);
   }
-} 
+}

--- a/packages/common/src/queue/README.md
+++ b/packages/common/src/queue/README.md
@@ -23,8 +23,8 @@ export const ContentMessageSchema = z.object({
 export type ContentMessage = z.infer<typeof ContentMessageSchema>;
 
 // 3. Create a queue wrapper subclass
-export class ContentQueue extends AbstractQueue<ContentMessage, typeof ContentMessageSchema> {
-  protected readonly schema = ContentMessageSchema;
+export class ContentQueue extends AbstractQueue<typeof ContentMessageSchema> {
+  static override schema = ContentMessageSchema;
 }
 ```
 

--- a/services/constellation/src/queues/DeadLetterQueue.ts
+++ b/services/constellation/src/queues/DeadLetterQueue.ts
@@ -11,6 +11,6 @@ export type DeadLetterMessage = z.infer<typeof EmbedDeadLetterMessageSchema>;
  * Type-safe wrapper for the dead letter queue.
  * Uses the existing EmbedDeadLetterMessageSchema from common.
  */
-export class DeadLetterQueue extends AbstractQueue<DeadLetterMessage, typeof EmbedDeadLetterMessageSchema> {
-  public static schema = EmbedDeadLetterMessageSchema;
+export class DeadLetterQueue extends AbstractQueue<typeof EmbedDeadLetterMessageSchema> {
+  static override schema = EmbedDeadLetterMessageSchema;
 }

--- a/services/constellation/src/queues/NewContentQueue.ts
+++ b/services/constellation/src/queues/NewContentQueue.ts
@@ -3,6 +3,6 @@ import { NewContentMessage, NewContentMessageSchema } from '@dome/common';
 
 export type { NewContentMessage };
 
-export class NewContentQueue extends AbstractQueue<NewContentMessage, typeof NewContentMessageSchema> {
-  public static schema = NewContentMessageSchema;
+export class NewContentQueue extends AbstractQueue<typeof NewContentMessageSchema> {
+  static override schema = NewContentMessageSchema;
 }

--- a/services/constellation/tests/newContentQueue.test.ts
+++ b/services/constellation/tests/newContentQueue.test.ts
@@ -3,7 +3,7 @@ import { NewContentQueue } from '../src/queues/NewContentQueue';
 import { NewContentMessageSchema } from '@dome/common';
 import * as queueHelpers from '@dome/common/queue';
 
-const mockQueue = { send: vi.fn() };
+const mockQueue = { send: vi.fn(), sendBatch: vi.fn() };
 
 const validMessage = { id: '1', userId: 'u' };
 


### PR DESCRIPTION
## Summary
- streamline queue wrapper generics
- add support for `Queue.sendBatch`
- update README and tests
- adjust constellation queues to new API
- remove dependency on `@cloudflare/workers-types`

## Testing
- `just build`
- `just lint` (warnings only)
- `just test`
