### PR TITLE
Add queue wrappers for ai-processor

### DIFF
--- a/services/ai-processor/src/index.ts
+++ b/services/ai-processor/src/index.ts
@@ -13,11 +13,9 @@ import { createLlmService } from './services/llmService';
 import {
   EnrichedContentMessage,
   NewContentMessage,
-  NewContentMessageSchema,
-  parseMessageBatch,
   ParsedMessageBatch,
-  toRawMessageBatch,
 } from '@dome/common';
+import { NewContentQueue } from './queues/NewContentQueue';
 import { SiloClient, SiloBinding } from '@dome/silo/client';
 import type { ServiceEnv } from './types';
 import { z } from 'zod';
@@ -354,10 +352,7 @@ export default class AiProcessor extends WorkerEntrypoint<ServiceEnv> {
 
         let parsed: ParsedMessageBatch<NewContentMessage>;
         try {
-          parsed = parseMessageBatch(
-            NewContentMessageSchema,
-            toRawMessageBatch(batch),
-          );
+          parsed = NewContentQueue.parseBatch(batch);
         } catch (err) {
           const domeError = toDomeError(err, 'Failed to parse message batch', {
             batchId,

--- a/services/ai-processor/src/queues/EnrichedContentQueue.ts
+++ b/services/ai-processor/src/queues/EnrichedContentQueue.ts
@@ -1,0 +1,8 @@
+import { AbstractQueue } from '@dome/common/queue';
+import { EnrichedContentMessage, EnrichedContentMessageSchema } from '@dome/common';
+
+export type { EnrichedContentMessage };
+
+export class EnrichedContentQueue extends AbstractQueue<typeof EnrichedContentMessageSchema> {
+  static override schema = EnrichedContentMessageSchema;
+}

--- a/services/ai-processor/src/queues/NewContentQueue.ts
+++ b/services/ai-processor/src/queues/NewContentQueue.ts
@@ -1,0 +1,8 @@
+import { AbstractQueue } from '@dome/common/queue';
+import { NewContentMessage, NewContentMessageSchema } from '@dome/common';
+
+export type { NewContentMessage };
+
+export class NewContentQueue extends AbstractQueue<typeof NewContentMessageSchema> {
+  static override schema = NewContentMessageSchema;
+}

--- a/services/ai-processor/src/queues/RateLimitDlqQueue.ts
+++ b/services/ai-processor/src/queues/RateLimitDlqQueue.ts
@@ -1,0 +1,8 @@
+import { AbstractQueue } from '@dome/common/queue';
+import { NewContentMessage, NewContentMessageSchema } from '@dome/common';
+
+export type { NewContentMessage };
+
+export class RateLimitDlqQueue extends AbstractQueue<typeof NewContentMessageSchema> {
+  static override schema = NewContentMessageSchema;
+}

--- a/services/ai-processor/src/queues/TodoQueue.ts
+++ b/services/ai-processor/src/queues/TodoQueue.ts
@@ -1,0 +1,52 @@
+import { AbstractQueue } from '@dome/common/queue';
+import { PUBLIC_USER_ID, EnrichedContentMessage } from '@dome/common';
+import { TodoQueueItem, TodoQueueItemSchema } from '@dome/todos/client';
+import { getLogger } from '../utils/logging';
+
+const logger = getLogger();
+
+export type { TodoQueueItem };
+
+export class TodoQueue extends AbstractQueue<typeof TodoQueueItemSchema> {
+  static override schema = TodoQueueItemSchema;
+
+  /**
+   * Convert todos in an EnrichedContentMessage and send them to the queue.
+   */
+  async dispatchFromEnriched(content: EnrichedContentMessage): Promise<void> {
+    const todos = content.metadata.todos;
+    if (!content.userId || content.userId === PUBLIC_USER_ID) {
+      logger.debug(
+        { contentId: content.id },
+        'No user ID found for content, skipping todo processing',
+      );
+      return;
+    }
+
+    if (!Array.isArray(todos) || todos.length === 0) {
+      logger.debug(
+        { contentId: content.id, userId: content.userId },
+        'No todos to send to queue',
+      );
+      return;
+    }
+
+    const userId = content.userId;
+    const contentId = content.id;
+
+    const todoItems: TodoQueueItem[] = todos.map(todo => ({
+      userId,
+      sourceNoteId: contentId,
+      sourceText: content.metadata.summary || content.metadata.title || todo.text,
+      description: todo.text,
+      title: todo.text.slice(0, Math.min(todo.text.length, 100)),
+      priority: todo.priority,
+      dueDate: todo.dueDate,
+      created: Date.now(),
+    }));
+
+    for (const item of todoItems) {
+      await this.send(item);
+    }
+  }
+}

--- a/services/ai-processor/tests/todos.test.ts
+++ b/services/ai-processor/tests/todos.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 import { sendTodosToQueue } from '../src/todos';
 import { PUBLIC_USER_ID } from '@dome/common';
+import { TodoQueue } from '../src/queues/TodoQueue';
 
-const makeQueue = () => ({ send: vi.fn() });
+const makeQueue = () => {
+  const binding = { send: vi.fn(), sendBatch: vi.fn() };
+  return { wrapper: new TodoQueue(binding as any), binding };
+};
 
 const baseContent = {
   id: '1',
@@ -20,22 +24,22 @@ const baseContent = {
 
 describe('sendTodosToQueue', () => {
   it('sends todos when userId present', async () => {
-    const q = makeQueue();
-    await sendTodosToQueue(baseContent as any, q as any);
-    expect(q.send).toHaveBeenCalledTimes(1);
-    const sent = JSON.parse(q.send.mock.calls[0][0]);
+    const { wrapper, binding } = makeQueue();
+    await sendTodosToQueue(baseContent as any, wrapper as any);
+    expect(binding.send).toHaveBeenCalledTimes(1);
+    const sent = JSON.parse(binding.send.mock.calls[0][0]);
     expect(sent).toMatchObject({ userId: 'u1', description: 'a' });
   });
 
   it('skips when no userId', async () => {
-    const q = makeQueue();
-    await sendTodosToQueue({ ...baseContent, userId: null } as any, q as any);
-    expect(q.send).not.toHaveBeenCalled();
+    const { wrapper, binding } = makeQueue();
+    await sendTodosToQueue({ ...baseContent, userId: null } as any, wrapper as any);
+    expect(binding.send).not.toHaveBeenCalled();
   });
 
   it('skips public user', async () => {
-    const q = makeQueue();
-    await sendTodosToQueue({ ...baseContent, userId: PUBLIC_USER_ID } as any, q as any);
-    expect(q.send).not.toHaveBeenCalled();
+    const { wrapper, binding } = makeQueue();
+    await sendTodosToQueue({ ...baseContent, userId: PUBLIC_USER_ID } as any, wrapper as any);
+    expect(binding.send).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add typed queue wrappers for ai-processor
- update todos helper to use `TodoQueue`
- instantiate queue wrappers in `ContentProcessor`
- parse batches with `NewContentQueue`
- adjust tests for wrapper usage

## Testing
- `just lint`
- `just build`
- `just test`