### PR TITLE
Add TodoQueue wrapper for todos service

### DIFF
--- a/services/todos/src/client/index.ts
+++ b/services/todos/src/client/index.ts
@@ -18,7 +18,8 @@ import {
   TodoQueueItem,
   TodoQueueItemSchema,
 } from '../types';
-import { getLogger, serializeQueueMessage } from '@dome/common';
+import { getLogger } from '@dome/common';
+import { TodoQueue } from '../queues/TodoQueue';
 import { createServiceMetrics } from '@dome/common';
 
 export {
@@ -193,10 +194,10 @@ export async function sendTodosToQueue(
   });
 
   try {
+    const wrapper = new TodoQueue(queue);
     // Send each todo individually since queue.send doesn't support arrays
     for (const todo of todosArray) {
-      const serialized = serializeQueueMessage(TodoQueueItemSchema, todo);
-      await queue.send(serialized);
+      await wrapper.send(todo);
     }
 
     logger.info(

--- a/services/todos/src/queueConsumer.ts
+++ b/services/todos/src/queueConsumer.ts
@@ -1,12 +1,7 @@
-import { Env, TodoJob, TodoQueueItemSchema, TodoQueueItem } from './types';
+import { Env, TodoJob, TodoQueueItem } from './types';
 import { TodosService } from './services/todosService';
-import {
-  getLogger,
-  logError,
-  parseMessageBatch,
-  ParsedMessageBatch,
-  toRawMessageBatch,
-} from '@dome/common';
+import { getLogger, logError, ParsedMessageBatch } from '@dome/common';
+import { TodoQueue } from './queues/TodoQueue';
 import { AiProcessorAdapter } from './adapters/aiProcessorAdapter';
 
 const logger = getLogger();
@@ -35,10 +30,7 @@ export async function processTodoQueue(
   // Convert the incoming batch to typed queue items
   let parsed: ParsedMessageBatch<TodoQueueItem>;
   try {
-    parsed = parseMessageBatch(
-      TodoQueueItemSchema,
-      toRawMessageBatch(batch),
-    );
+    parsed = TodoQueue.parseBatch(batch);
   } catch (error) {
     logError(error, 'Failed to parse todo queue batch');
     return;

--- a/services/todos/src/queues/TodoQueue.ts
+++ b/services/todos/src/queues/TodoQueue.ts
@@ -1,0 +1,8 @@
+import { AbstractQueue } from '@dome/common/queue';
+import { TodoQueueItem, TodoQueueItemSchema } from '../types';
+
+export type { TodoQueueItem };
+
+export class TodoQueue extends AbstractQueue<typeof TodoQueueItemSchema> {
+  static override schema = TodoQueueItemSchema;
+}

--- a/services/todos/tests/queueSchema.test.ts
+++ b/services/todos/tests/queueSchema.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { TodoQueueItemSchema } from '../src/types';
-import { parseMessageBatch, RawMessageBatch, MessageProcessingError } from '@dome/common';
+import { MessageBatch, MessageProcessingError } from '@dome/common';
+import { TodoQueue } from '../src/queues/TodoQueue';
 
 const validItem = {
   userId: 'u',
@@ -11,23 +11,23 @@ const validItem = {
 
 describe('TodoQueueItemSchema', () => {
   it('parses a valid batch', () => {
-    const batch: RawMessageBatch = {
+    const batch: MessageBatch<string> = {
       queue: 'todos',
       messages: [
-        { id: '1', timestamp: 1, body: JSON.stringify(validItem) },
+        { id: '1', timestamp: new Date(1), body: JSON.stringify(validItem) },
       ],
     };
-    const parsed = parseMessageBatch(TodoQueueItemSchema, batch);
+    const parsed = TodoQueue.parseBatch(batch);
     expect(parsed.messages[0].body.userId).toBe('u');
   });
 
   it('throws on invalid message', () => {
-    const batch: RawMessageBatch = {
+    const batch: MessageBatch<string> = {
       queue: 'todos',
       messages: [
-        { id: '1', timestamp: 1, body: JSON.stringify({ userId: 'u' }) },
+        { id: '1', timestamp: new Date(1), body: JSON.stringify({ userId: 'u' }) },
       ],
     };
-    expect(() => parseMessageBatch(TodoQueueItemSchema, batch)).toThrow(MessageProcessingError);
+    expect(() => TodoQueue.parseBatch(batch)).toThrow(MessageProcessingError);
   });
 });


### PR DESCRIPTION
## Summary
- implement `TodoQueue` class in todos service
- use `TodoQueue.parseBatch` in queue consumer
- send todos via the new wrapper in client helper
- update queue schema tests for new wrapper API

## Testing
- `just lint-pkg todos`
- `just test-pkg todos`
- `just build-pkg todos`
