### PR TITLE
feat(silo): add queue wrappers

### DIFF
--- a/services/dome-api/src/services/serviceFactory.ts
+++ b/services/dome-api/src/services/serviceFactory.ts
@@ -1,6 +1,6 @@
 import { Bindings } from '../types';
 import { getLogger } from '@dome/common';
-import { SiloClient, SiloBinding } from '@dome/silo/client';
+import { SiloClient, createSiloClient, SiloBinding } from '@dome/silo/client';
 import { ConstellationClient, ConstellationBinding } from '@dome/constellation/client';
 import { AiProcessorClient, AiProcessorBinding } from '@dome/ai-processor/client';
 import { SearchService } from './searchService';
@@ -100,7 +100,7 @@ export class DefaultServiceFactory implements ServiceFactory {
     let service = this.siloServices.get(env);
     if (!service) {
       this.logger.debug('Creating new SiloClient instance');
-      service = new SiloClient(env.SILO, env.SILO_INGEST_QUEUE);
+      service = createSiloClient(env.SILO, env.SILO_INGEST_QUEUE as any);
       this.siloServices.set(env, service);
     }
     return service;

--- a/services/silo/src/queues/EnrichedContentQueue.ts
+++ b/services/silo/src/queues/EnrichedContentQueue.ts
@@ -1,0 +1,8 @@
+import { AbstractQueue } from '@dome/common/queue';
+import { EnrichedContentMessage, EnrichedContentMessageSchema } from '@dome/common';
+
+export type { EnrichedContentMessage };
+
+export class EnrichedContentQueue extends AbstractQueue<typeof EnrichedContentMessageSchema> {
+  static override schema = EnrichedContentMessageSchema;
+}

--- a/services/silo/src/queues/IngestDlqQueue.ts
+++ b/services/silo/src/queues/IngestDlqQueue.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { AbstractQueue } from '@dome/common/queue';
+import type { DLQMessage } from '../types';
+
+export const DLQMessageSchema = z.object({
+  originalMessage: z.any(),
+  error: z.object({
+    message: z.string(),
+    name: z.string(),
+    stack: z.string().optional(),
+  }),
+  processingMetadata: z.object({
+    failedAt: z.number(),
+    retryCount: z.number(),
+    queueName: z.string(),
+    messageId: z.string(),
+    producerService: z.string().optional(),
+  }),
+  recovery: z.object({
+    reprocessed: z.boolean(),
+    reprocessedAt: z.number().optional(),
+    recoveryResult: z.string().optional(),
+  }),
+});
+
+export type IngestDlqMessage = DLQMessage<unknown>;
+
+export class IngestDlqQueue extends AbstractQueue<typeof DLQMessageSchema> {
+  static override schema = DLQMessageSchema;
+}

--- a/services/silo/src/queues/IngestQueue.ts
+++ b/services/silo/src/queues/IngestQueue.ts
@@ -1,0 +1,9 @@
+import { AbstractQueue } from '@dome/common/queue';
+import { siloSimplePutSchema } from '@dome/common';
+import { z } from 'zod';
+
+export type IngestMessage = z.infer<typeof siloSimplePutSchema>;
+
+export class IngestQueue extends AbstractQueue<typeof siloSimplePutSchema> {
+  static override schema = siloSimplePutSchema;
+}

--- a/services/silo/src/queues/NewContentQueue.ts
+++ b/services/silo/src/queues/NewContentQueue.ts
@@ -1,0 +1,8 @@
+import { AbstractQueue } from '@dome/common/queue';
+import { NewContentMessage, NewContentMessageSchema } from '@dome/common';
+
+export type { NewContentMessage };
+
+export class NewContentQueue extends AbstractQueue<typeof NewContentMessageSchema> {
+  static override schema = NewContentMessageSchema;
+}

--- a/services/silo/src/queues/R2EventQueue.ts
+++ b/services/silo/src/queues/R2EventQueue.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+import { AbstractQueue } from '@dome/common/queue';
+import type { R2Event } from '../types';
+
+export const R2EventSchema = z.object({
+  account: z.string(),
+  bucket: z.string(),
+  eventTime: z.string(),
+  action: z.string(),
+  object: z.object({
+    key: z.string(),
+    eTag: z.string(),
+    size: z.number(),
+  }),
+});
+
+export type { R2Event };
+
+export class R2EventQueue extends AbstractQueue<typeof R2EventSchema> {
+  static override schema = R2EventSchema;
+}

--- a/services/silo/src/queues/index.ts
+++ b/services/silo/src/queues/index.ts
@@ -1,0 +1,5 @@
+export { NewContentQueue } from './NewContentQueue';
+export { IngestQueue } from './IngestQueue';
+export { EnrichedContentQueue } from './EnrichedContentQueue';
+export { IngestDlqQueue } from './IngestDlqQueue';
+export { R2EventQueue } from './R2EventQueue';


### PR DESCRIPTION
## Summary
- create queue wrapper classes for silo service
- refactor SiloClient to use `IngestQueue`
- use wrappers in queueService, dlqService and queue processing
- update serviceFactory to construct SiloClient correctly

## Testing
- `just lint`
- `just build`
- `just test`
