### PR TITLE
Update SiloClient queue handling

### DIFF
--- a/services/silo/src/client/client.ts
+++ b/services/silo/src/client/client.ts
@@ -35,10 +35,10 @@ export class SiloClient {
    */
   constructor(
     private readonly binding: SiloBinding,
-    queueBinding?: Queue,
+    queue?: IngestQueue,
     private readonly metricsPrefix: string = 'silo.client',
   ) {
-    this.queue = queueBinding ? new IngestQueue(queueBinding) : undefined;
+    this.queue = queue;
   }
 
   /**
@@ -358,8 +358,8 @@ export class SiloClient {
  */
 export function createSiloClient(
   binding: SiloBinding,
-  queue: Queue,
+  queueBinding: Queue,
   metricsPrefix?: string,
 ): SiloClient {
-  return new SiloClient(binding, queue, metricsPrefix);
+  return new SiloClient(binding, new IngestQueue(queueBinding), metricsPrefix);
 }

--- a/services/tsunami/src/index.ts
+++ b/services/tsunami/src/index.ts
@@ -15,6 +15,7 @@ import { createSyncPlanService } from './services/syncPlanService';
 import { TokenService } from './services/tokenService';
 import type { NotionOAuthDetails, GithubOAuthDetails } from './client/types'; // Added GithubOAuthDetails
 import { SiloClient, SiloBinding } from '@dome/silo/client';
+import { IngestQueue } from '@dome/silo/queues';
 interface ServiceEnv extends Omit<Cloudflare.Env, 'SILO'> {
   SILO: SiloBinding;
 }
@@ -29,7 +30,7 @@ const logger = getLogger();
 const metrics = createServiceMetrics('tsunami');
 
 const buildServices = (env: ServiceEnv) => ({
-  silo: new SiloClient(env.SILO, env.SILO_INGEST_QUEUE),
+  silo: new SiloClient(env.SILO, new IngestQueue(env.SILO_INGEST_QUEUE)),
   syncPlan: createSyncPlanService(env),
   token: new TokenService(env.SYNC_PLAN, (env as any).TOKEN_ENCRYPTION_KEY || ''),
 });

--- a/services/tsunami/src/resourceObject.ts
+++ b/services/tsunami/src/resourceObject.ts
@@ -1,6 +1,7 @@
 import { DurableObject } from 'cloudflare:workers';
 import { getLogger, logError, metrics } from '@dome/common';
 import { SiloClient, SiloBinding } from '@dome/silo/client';
+import { IngestQueue } from '@dome/silo/queues';
 
 export interface ServiceEnv extends Omit<Cloudflare.Env, 'SILO'> {
   SILO: SiloBinding;
@@ -57,7 +58,7 @@ export class ResourceObject extends DurableObject<ServiceEnv> {
 
   constructor(ctx: any, env: ServiceEnv) {
     super(ctx, env);
-    (this.silo = new SiloClient(env.SILO, env.SILO_INGEST_QUEUE)),
+    (this.silo = new SiloClient(env.SILO, new IngestQueue(env.SILO_INGEST_QUEUE))),
       // Load stored configuration (do **not** throw – an empty cfg just means un‑initialised).
       ctx.blockConcurrencyWhile(async () => {
         const stored = await ctx.storage.get(STORAGE_KEY);


### PR DESCRIPTION
## Summary
- update SiloClient to accept `IngestQueue`
- construct `SiloClient` with typed queue in Tsunami service

## Testing
- `just lint`
- `just build`
- `just test`
