### PR TITLE
Expose silo queues via client

### DIFF
--- a/services/silo/src/client/index.ts
+++ b/services/silo/src/client/index.ts
@@ -9,3 +9,4 @@ import { SiloClient, createSiloClient } from './client';
 import { SiloBinding } from '../types';
 
 export { SiloClient, SiloBinding, createSiloClient };
+export * from '../queues';


### PR DESCRIPTION
## Summary
- re-export silo queues from client interface
- remove unused barrel export entry

## Testing
- `just lint-pkg silo`
- `just build-pkg silo`
- `just test-pkg silo`
