### PR TITLE
Remove duplicated NewContentQueue

### DIFF
--- a/services/ai-processor/src/index.ts
+++ b/services/ai-processor/src/index.ts
@@ -15,7 +15,7 @@ import {
   NewContentMessage,
   ParsedMessageBatch,
 } from '@dome/common';
-import { NewContentQueue } from './queues/NewContentQueue';
+import { NewContentQueue } from '@dome/silo/queues';
 import { SiloClient, SiloBinding } from '@dome/silo/client';
 import type { ServiceEnv } from './types';
 import { z } from 'zod';

--- a/services/ai-processor/src/queues/NewContentQueue.ts
+++ b/services/ai-processor/src/queues/NewContentQueue.ts
@@ -1,8 +1,0 @@
-import { AbstractQueue } from '@dome/common/queue';
-import { NewContentMessage, NewContentMessageSchema } from '@dome/common';
-
-export type { NewContentMessage };
-
-export class NewContentQueue extends AbstractQueue<typeof NewContentMessageSchema> {
-  static override schema = NewContentMessageSchema;
-}

--- a/services/constellation/src/index.ts
+++ b/services/constellation/src/index.ts
@@ -28,7 +28,7 @@ import { createVectorizeService } from './services/vectorize';
 import { SiloClient, SiloBinding } from '@dome/silo/client';
 import { Queue } from '@cloudflare/workers-types/experimental';
 import { DeadLetterQueue } from './queues/DeadLetterQueue';
-import { NewContentQueue } from './queues/NewContentQueue';
+import { NewContentQueue } from '@dome/silo/queues';
 
 interface ServiceEnv extends Omit<Cloudflare.Env, 'SILO'> {
   SILO: SiloBinding;

--- a/services/constellation/src/queues/NewContentQueue.ts
+++ b/services/constellation/src/queues/NewContentQueue.ts
@@ -1,8 +1,0 @@
-import { AbstractQueue } from '@dome/common/queue';
-import { NewContentMessage, NewContentMessageSchema } from '@dome/common';
-
-export type { NewContentMessage };
-
-export class NewContentQueue extends AbstractQueue<typeof NewContentMessageSchema> {
-  static override schema = NewContentMessageSchema;
-}

--- a/services/constellation/tests/newContentQueue.test.ts
+++ b/services/constellation/tests/newContentQueue.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { NewContentQueue } from '../src/queues/NewContentQueue';
+import { NewContentQueue } from '@dome/silo/queues';
 import { NewContentMessageSchema } from '@dome/common';
 import * as queueHelpers from '@dome/common/queue';
 

--- a/services/constellation/tests/queue.integration.test.ts
+++ b/services/constellation/tests/queue.integration.test.ts
@@ -10,7 +10,7 @@ vi.mock('@dome/common', async () => {
   };
 });
 
-vi.mock('../src/queues/NewContentQueue', () => ({
+vi.mock('@dome/silo/queues', () => ({
   NewContentQueue: {
     parseBatch: (batch: any) => ({
       queue: batch.queue,


### PR DESCRIPTION
## Summary
- remove redundant queue implementations from ai-processor and constellation
- import NewContentQueue from `@dome/silo/queues`
- update constellation tests for new import path

## Testing
- `pnpm install`
- `just build`
- `just lint`
- `just test`