### PR TITLE
Fix migration validation command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,4 +61,4 @@ jobs:
         
       - name: Validate D1 Migrations
         if: github.ref == 'refs/heads/main'
-        run: wrangler d1 migrations apply dome_meta --dry-run
+        run: wrangler d1 migrations apply dome-meta --local


### PR DESCRIPTION
## Summary
- fix D1 migrations validation step in CI

## Testing
- `just lint`
- `just test`
- `just build` *(failed: EHOSTUNREACH errors)*