### PR TITLE
Remove redundant EnrichedContentQueue implementation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,9 +153,6 @@ importers:
 
   packages/common:
     dependencies:
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../errors
       hono:
         specifier: ^4.0.0
         version: 4.7.8

--- a/services/silo/src/index.ts
+++ b/services/silo/src/index.ts
@@ -33,8 +33,8 @@ import {
   SiloDeleteResponse,
   SiloStatsResponse,
 } from '@dome/common';
+import { EnrichedContentQueue } from '@dome/ai-processor/client';
 import {
-  EnrichedContentQueue,
   IngestQueue,
   IngestDlqQueue,
   R2EventQueue,

--- a/services/silo/src/queues/EnrichedContentQueue.ts
+++ b/services/silo/src/queues/EnrichedContentQueue.ts
@@ -1,8 +1,0 @@
-import { AbstractQueue } from '@dome/common/queue';
-import { EnrichedContentMessage, EnrichedContentMessageSchema } from '@dome/common';
-
-export type { EnrichedContentMessage };
-
-export class EnrichedContentQueue extends AbstractQueue<typeof EnrichedContentMessageSchema> {
-  static override schema = EnrichedContentMessageSchema;
-}

--- a/services/silo/src/queues/index.ts
+++ b/services/silo/src/queues/index.ts
@@ -1,5 +1,4 @@
 export { NewContentQueue } from './NewContentQueue';
 export { IngestQueue } from './IngestQueue';
-export { EnrichedContentQueue } from './EnrichedContentQueue';
 export { IngestDlqQueue } from './IngestDlqQueue';
 export { R2EventQueue } from './R2EventQueue';


### PR DESCRIPTION
## Summary
- remove local `EnrichedContentQueue` from Silo service
- update Silo queue import to use `@dome/ai-processor/client`

## Testing
- `just lint`
- `just test`
- `just build` *(fails: EHOSTUNREACH npm registry)*
