### PR TITLE
Fix imports for local error module

### DIFF
--- a/packages/common/src/errors/errorUtils.ts
+++ b/packages/common/src/errors/errorUtils.ts
@@ -2,6 +2,7 @@
  * Error utilities that work with domeErrors module
  */
 import { getLogger } from '@dome/common';
+import { toDomeError as baseToDomeError, assertValid as originalAssertValid } from './domeErrors.js';
 
 /**
  * Enhanced toDomeError function with service-specific context
@@ -13,9 +14,6 @@ import { getLogger } from '@dome/common';
  * @returns A DomeError instance
  */
 export function createServiceErrorHandler(serviceName: string) {
-  // Import locally at runtime to avoid potential circular dependencies
-  const { toDomeError: baseToDomeError } = require('./domeErrors.js');
-
   return function toDomeError(
     error: unknown,
     defaultMessage = `An unexpected error occurred in ${serviceName} service`,
@@ -32,9 +30,6 @@ export function createServiceErrorHandler(serviceName: string) {
  * Enhanced version of assertValid that explicitly converts string expressions to boolean
  */
 export function createEnhancedAssertValid() {
-  // Import locally at runtime to avoid potential circular dependencies
-  const { assertValid: originalAssertValid } = require('./domeErrors.js');
-
   return function assertValid(
     condition: string | boolean | undefined | null,
     message: string,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -9,6 +9,7 @@ export * from './context/index.js';
 
 // Export all errors
 export * from './errors/index.js';
+export { DomeError } from './errors/domeErrors.js';
 
 // Export all middleware
 export * from './middleware/index.js';

--- a/packages/common/src/utils/functionWrapper.ts
+++ b/packages/common/src/utils/functionWrapper.ts
@@ -1,12 +1,8 @@
 import { getLogger, logError, trackOperation } from '@dome/common';
 import { withContext } from '@dome/common';
+import { toDomeError, DomeError } from '../errors/domeErrors.js';
 
-// Use type reference for DomeError without importing it
-type DomeError = {
-  message: string;
-  code?: string;
-  details?: Record<string, any>;
-};
+// DomeError type re-exported for convenience
 
 /**
  * Wraps a function call with logging context specific to a service.
@@ -18,8 +14,6 @@ type DomeError = {
  * @returns The result of the function execution
  */
 export function createServiceWrapper(serviceName: string) {
-  // Import at runtime to avoid circular dependencies
-  const { toDomeError } = require('../errors/domeErrors.js');
 
   return async function wrap<T>(meta: Record<string, unknown>, fn: () => Promise<T>): Promise<T> {
     // Extract operation name if present for better error context
@@ -42,8 +36,6 @@ export function createServiceWrapper(serviceName: string) {
         // Otherwise just run the function
         return await fn();
       } catch (err) {
-        // Get toDomeError at runtime
-        const { toDomeError } = require('../errors/domeErrors.js');
 
         // Convert to DomeError for consistent handling
         const domeError =

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -203,7 +203,7 @@ export default class Auth extends WorkerEntrypoint<Env> {
       const domeError = authToDomeError(err, 'An unexpected API error occurred');
       return c.json(
         { error: { code: domeError.code, message: domeError.message, details: domeError.details } },
-        domeError.status as any,
+        domeError.statusCode as any,
       );
     });
 


### PR DESCRIPTION
## Summary
- adjust errorUtils and functionWrapper to statically import local error helpers
- export `DomeError` from `@dome/common`
- fix auth service to use `statusCode`

## Testing
- `just lint`
- `just build-no-install`
- `just test`
