### PR TITLE
refactor: align service error imports

### DIFF
--- a/services/ai-processor/src/index.ts
+++ b/services/ai-processor/src/index.ts
@@ -28,7 +28,7 @@ import {
   aiProcessorMetrics,
 } from './utils/logging';
 import { ReprocessResponseSchema, ReprocessRequestSchema } from './types';
-import { assertExists } from './utils/errors';
+import { domeAssertExists as assertExists } from '@dome/common/errors';
 import { ContentProcessor } from './utils/processor';
 
 /**

--- a/services/ai-processor/src/services/llmService.ts
+++ b/services/ai-processor/src/services/llmService.ts
@@ -1,5 +1,6 @@
 import { getLogger, logError, trackOperation } from '../utils/logging';
-import { toDomeError, LLMProcessingError, assertValid } from '../utils/errors';
+import { LLMProcessingError } from '../utils/errors';
+import { toDomeError, domeAssertValid as assertValid } from '@dome/common/errors';
 import type { ServiceEnv } from '../types';
 import { getSchemaForContentType, getSchemaInstructions } from '../schemas';
 import {

--- a/services/ai-processor/src/todos.ts
+++ b/services/ai-processor/src/todos.ts
@@ -6,7 +6,7 @@
 import { getLogger, trackOperation } from './utils/logging';
 import { TodoQueueItem } from '@dome/todos/client';
 import { PUBLIC_USER_ID, EnrichedContentMessage } from '@dome/common';
-import { toDomeError } from './utils/errors';
+import { toDomeError } from '@dome/common/errors';
 import { TodoQueue } from '@dome/todos/client';
 
 const logger = getLogger();

--- a/services/ai-processor/src/utils/errors.ts
+++ b/services/ai-processor/src/utils/errors.ts
@@ -8,7 +8,7 @@ import {
   domeAssertValid as assertValid,
   domeAssertExists as assertExists,
   createErrorFactory,
-} from '@dome/common';
+} from '@dome/common/errors';
 
 // Create domain-specific error factory
 export const AiProcessorErrors = createErrorFactory('aiprocessor', {
@@ -73,4 +73,3 @@ export function determineErrorType(error: unknown): string {
   return domeError.code;
 }
 
-export { toDomeError, assertValid, assertExists };

--- a/services/ai-processor/src/utils/processor.ts
+++ b/services/ai-processor/src/utils/processor.ts
@@ -9,12 +9,11 @@
 // ───────────────────────────────────────────────────────────────
 
 import { getLogger, logError, sanitizeForLogging, aiProcessorMetrics } from './logging';
+import { LLMProcessingError, ContentProcessingError } from '../utils/errors';
 import {
-  assertExists,
+  domeAssertExists as assertExists,
   toDomeError,
-  LLMProcessingError,
-  ContentProcessingError,
-} from '../utils/errors';
+} from '@dome/common/errors';
 import { sendTodosToQueue } from '../todos';
 import { EnrichedContentQueue } from '../queues/EnrichedContentQueue';
 import { RateLimitDlqQueue } from '../queues/RateLimitDlqQueue';

--- a/services/chat/src/controllers/chatController.ts
+++ b/services/chat/src/controllers/chatController.ts
@@ -5,7 +5,8 @@ import {
   getModelConfig,
   calculateContextLimits,
 } from '@dome/common';
-import { toDomeError, ValidationError } from '../utils/errors';
+import { toDomeError } from '../utils/errors';
+import { ValidationError } from '@dome/common/errors';
 import { IterableReadableStream } from '@langchain/core/utils/stream';
 import {
   chatRequestSchema,

--- a/services/chat/src/nodes/combineContext.ts
+++ b/services/chat/src/nodes/combineContext.ts
@@ -2,7 +2,7 @@ import { getLogger, logError } from '@dome/common';
 import { ObservabilityService } from '../services/observabilityService';
 import { Document } from '../types';
 import { AgentStateV3 as AgentState } from '../types/stateSlices';
-import { toDomeError } from '../utils/errors';
+import { toDomeError } from '@dome/common/errors';
 import { countTokens } from '../utils/tokenCounter';
 import { getModelDocumentLimits } from '../config/retrieveConfig';
 import type { SliceUpdate } from '../types/stateSlices';

--- a/services/chat/src/nodes/editSystemPrompt.ts
+++ b/services/chat/src/nodes/editSystemPrompt.ts
@@ -1,6 +1,7 @@
 import { getLogger } from '@dome/common';
 import type { SliceUpdate } from '../types/stateSlices';
-import { NodeError, toDomeError } from '../utils/errors';
+import { NodeError } from '../utils/errors';
+import { toDomeError } from '@dome/common/errors';
 import { z } from 'zod';
 import { AgentStateV3 as AgentState } from '../types/stateSlices';
 import { getUserId } from '../utils/stateUtils';

--- a/services/chat/src/nodes/generateAnswer.ts
+++ b/services/chat/src/nodes/generateAnswer.ts
@@ -1,6 +1,6 @@
 import { getLogger, logError, countTokens, chooseModel, allocateContext } from '@dome/common';
 import { LlmService } from '../services/llmService';
-import { toDomeError } from '../utils/errors';
+import { toDomeError } from '@dome/common/errors';
 import { LangGraphRunnableConfig } from '@langchain/langgraph';
 import { formatDocsForPrompt } from '../utils/promptHelpers';
 import { AgentStateV3 as AgentState } from '../types/stateSlices';

--- a/services/chat/src/nodes/reranker/index.ts
+++ b/services/chat/src/nodes/reranker/index.ts
@@ -24,7 +24,7 @@ import {
 } from './core';
 import { CohereReranker } from './impl/cohere';
 import { WorkersAIReranker } from './impl/workersAi';
-import { toDomeError } from '../../utils/errors';
+import { toDomeError } from '@dome/common/errors';
 import { AgentStateV3 as AgentState } from '../../types/stateSlices';
 import type { SliceUpdate } from '../../types/stateSlices';
 

--- a/services/chat/src/nodes/retrievalEvaluatorLLM.ts
+++ b/services/chat/src/nodes/retrievalEvaluatorLLM.ts
@@ -4,7 +4,7 @@ import { DocumentChunk, RetrievalEvaluation, RetrievalTask } from '../types';
 import { AgentStateV3 as AgentState } from '../types/stateSlices';
 import { ObservabilityService } from '../services/observabilityService';
 import { LlmService } from '../services/llmService';
-import { toDomeError } from '../utils/errors';
+import { toDomeError } from '@dome/common/errors';
 import { getRetrievalEvaluationPrompt } from '../config/promptsConfig';
 import type { SliceUpdate } from '../types/stateSlices';
 import { z } from 'zod';

--- a/services/chat/src/nodes/retrievalSelector.ts
+++ b/services/chat/src/nodes/retrievalSelector.ts
@@ -7,7 +7,7 @@ import { AgentStateV3 as AgentState } from '../types/stateSlices';
 import type { SliceUpdate } from '../types/stateSlices';
 import { LlmService } from '../services/llmService';
 import { ObservabilityService } from '../services/observabilityService';
-import { toDomeError } from '../utils/errors';
+import { toDomeError } from '@dome/common/errors';
 import { z } from 'zod';
 import { getRetrievalSelectionPrompt } from '../config/promptsConfig';
 

--- a/services/chat/src/nodes/retrieve.ts
+++ b/services/chat/src/nodes/retrieve.ts
@@ -3,7 +3,7 @@ import { RETRIEVAL_TOOLS } from '../tools';
 import { LangGraphRunnableConfig } from '@langchain/langgraph';
 import { RetrievalToolType, RetrievalTask, DocumentChunk, RetrievalResult } from '../types';
 import { ObservabilityService } from '../services/observabilityService';
-import { toDomeError } from '../utils/errors';
+import { toDomeError } from '@dome/common/errors';
 import { AgentStateV3 as AgentState } from '../types/stateSlices';
 import type { SliceUpdate } from '../types/stateSlices';
 

--- a/services/chat/src/nodes/runTool.ts
+++ b/services/chat/src/nodes/runTool.ts
@@ -4,7 +4,7 @@ import { ToolRegistry } from '../tools';
 import { Document, ToolResult } from '../types';
 import { AgentStateV3 as AgentState } from '../types/stateSlices';
 import type { SliceUpdate } from '../types/stateSlices';
-import { toDomeError } from '../utils/errors';
+import { toDomeError } from '@dome/common/errors';
 
 /**
  * Run Tool Node

--- a/services/chat/src/utils/errors.ts
+++ b/services/chat/src/utils/errors.ts
@@ -6,12 +6,10 @@ import {
   UnauthorizedError,
   createErrorFactory,
   domeAssertExists as assertExists,
-} from '@dome/common';
-import {
   createServiceErrorHandler,
   createEnhancedAssertValid,
   createServiceErrorMiddleware,
-} from '@dome/common';
+} from '@dome/common/errors';
 
 // Service name constant for consistency
 const SERVICE_NAME = 'chat';
@@ -75,12 +73,3 @@ export class NodeError extends ServiceUnavailableError {
 }
 
 // Re-export common errors
-export {
-  ValidationError,
-  NotFoundError,
-  ConflictError,
-  ServiceUnavailableError,
-  UnauthorizedError,
-  assertExists,
-  createErrorFactory,
-};

--- a/services/constellation/src/index.ts
+++ b/services/constellation/src/index.ts
@@ -17,11 +17,13 @@ import {
 } from './utils/logging';
 import {
   toDomeError,
-  assertValid,
-  assertExists,
   VectorizeError,
   EmbeddingError,
 } from './utils/errors';
+import {
+  domeAssertValid as assertValid,
+  domeAssertExists as assertExists,
+} from '@dome/common/errors';
 import { createPreprocessor } from './services/preprocessor';
 import { createEmbedder } from './services/embedder';
 import { createVectorizeService } from './services/vectorize';

--- a/services/constellation/src/services/vectorize.ts
+++ b/services/constellation/src/services/vectorize.ts
@@ -9,7 +9,8 @@ import {
 } from '../utils/logging';
 
 const logger = getLogger();
-import { assertValid, VectorizeError, toDomeError } from '../utils/errors';
+import { VectorizeError } from '../utils/errors';
+import { domeAssertValid as assertValid, toDomeError } from '@dome/common/errors';
 import { sliceIntoBatches } from '../utils/batching';
 import { retryAsync, RetryConfig } from '../utils/retry';
 import { toIndexMetadata } from '../utils/metadata';

--- a/services/constellation/src/utils/errors.ts
+++ b/services/constellation/src/utils/errors.ts
@@ -7,8 +7,8 @@ import {
   domeAssertValid as assertValid,
   domeAssertExists as assertExists,
   createErrorFactory,
-} from '@dome/common';
-import { createServiceErrorHandler } from '@dome/common';
+  createServiceErrorHandler,
+} from '@dome/common/errors';
 
 // Service name constant for consistency
 const SERVICE_NAME = 'constellation';
@@ -70,11 +70,3 @@ export class PreprocessingError extends InternalError {
 }
 
 // Re-export common errors
-export {
-  ValidationError,
-  NotFoundError,
-  ConflictError,
-  ServiceUnavailableError,
-  assertValid,
-  assertExists,
-};

--- a/services/silo/src/controllers/contentController.ts
+++ b/services/silo/src/controllers/contentController.ts
@@ -1,5 +1,5 @@
 import { getLogger, logError, metrics } from '@dome/common';
-import { ValidationError, NotFoundError, UnauthorizedError, toDomeError } from '../utils/errors';
+import { ValidationError, NotFoundError, UnauthorizedError, toDomeError } from '@dome/common/errors';
 import { ulid } from 'ulid';
 import { R2Service } from '../services/r2Service';
 import { MetadataService } from '../services/metadataService';

--- a/services/silo/src/controllers/dlqController.ts
+++ b/services/silo/src/controllers/dlqController.ts
@@ -1,5 +1,5 @@
 import { getLogger, logError, metrics } from '@dome/common';
-import { toDomeError } from '../utils/errors';
+import { toDomeError } from '@dome/common/errors';
 import { DLQService } from '../services/dlqService';
 import { DLQFilterOptions, DLQMessage, DLQStats } from '../types';
 

--- a/services/silo/src/controllers/statsController.ts
+++ b/services/silo/src/controllers/statsController.ts
@@ -1,5 +1,5 @@
 import { getLogger, logError, metrics } from '@dome/common';
-import { toDomeError } from '../utils/errors';
+import { toDomeError } from '@dome/common/errors';
 import { SiloStatsResponse } from '@dome/common';
 import { MetadataService } from '../services/metadataService';
 

--- a/services/silo/src/utils/errors.ts
+++ b/services/silo/src/utils/errors.ts
@@ -6,12 +6,10 @@ import {
   UnauthorizedError,
   createErrorFactory,
   domeAssertExists as assertExists,
-} from '@dome/common';
-import {
   createServiceErrorHandler,
   createEnhancedAssertValid,
   createServiceErrorMiddleware,
-} from '@dome/common';
+} from '@dome/common/errors';
 
 // Service name constant for consistency
 const SERVICE_NAME = 'silo';
@@ -27,12 +25,3 @@ export const assertValid = createEnhancedAssertValid();
 export const createErrorMiddleware = createServiceErrorMiddleware(SERVICE_NAME);
 
 // Re-export common errors
-export {
-  ValidationError,
-  NotFoundError,
-  ConflictError,
-  ServiceUnavailableError,
-  UnauthorizedError,
-  assertExists,
-  createErrorFactory,
-};

--- a/services/tsunami/src/client/client.ts
+++ b/services/tsunami/src/client/client.ts
@@ -4,7 +4,7 @@
  * A client for interacting with the Tsunami service using WorkerEntrypoint RPC
  */
 import { getLogger, logError, metrics } from '@dome/common';
-import { toDomeError } from '../utils/errors';
+import { toDomeError } from '@dome/common/errors';
 import {
   TsunamiBinding,
   TsunamiService,

--- a/services/tsunami/src/index.ts
+++ b/services/tsunami/src/index.ts
@@ -10,7 +10,8 @@ import {
   trackOperation,
   createServiceMetrics,
 } from '@dome/common';
-import { toDomeError, ConflictError, ValidationError } from './utils/errors';
+import { toDomeError } from './utils/errors';
+import { ConflictError, ValidationError } from '@dome/common/errors';
 import { createSyncPlanService } from './services/syncPlanService';
 import { TokenService } from './services/tokenService';
 import type { NotionOAuthDetails, GithubOAuthDetails } from './client/types'; // Added GithubOAuthDetails

--- a/services/tsunami/src/services/ignoreFileService.ts
+++ b/services/tsunami/src/services/ignoreFileService.ts
@@ -9,7 +9,12 @@
  */
 
 import { getLogger, trackedFetch, trackOperation, getRequestId } from '@dome/common';
-import { ValidationError, NotFoundError, ServiceUnavailableError, toDomeError } from '@dome/common';
+import {
+  ValidationError,
+  NotFoundError,
+  ServiceUnavailableError,
+  toDomeError,
+} from '@dome/common';
 import { assertValid } from '../utils/errors';
 import { DEFAULT_IGNORE_PATTERNS } from '../config/defaultIgnorePatterns';
 import { DEFAULT_FILTER_CONFIG, FilterConfig } from '../config/filterConfig';

--- a/services/tsunami/src/utils/errors.ts
+++ b/services/tsunami/src/utils/errors.ts
@@ -8,7 +8,7 @@ import {
   domeAssertExists as originalAssertExists,
   createErrorFactory,
   errorHandler,
-} from '@dome/common';
+} from '@dome/common/errors';
 import { getLogger as getDomeLogger } from '@dome/common';
 
 // Create domain-specific error factory
@@ -100,11 +100,3 @@ export function createErrorMiddleware(
   };
 }
 
-export {
-  ValidationError,
-  NotFoundError,
-  ConflictError,
-  ServiceUnavailableError,
-  originalAssertExists as assertExists,
-  createErrorFactory,
-};


### PR DESCRIPTION
## Summary
- refactor service error helpers to use `@dome/common/errors`
- drop re‑exports of common errors
- update service files to import the helpers directly

## Testing
- `just build-no-install`
- `just lint`
- `just test`