### PR TITLE
Use new Dome error utilities

### DIFF
--- a/packages/common/src/errors/errorUtils.ts
+++ b/packages/common/src/errors/errorUtils.ts
@@ -3,6 +3,7 @@
  */
 import { getLogger } from '@dome/common';
 import { toDomeError as baseToDomeError, assertValid as originalAssertValid } from './domeErrors.js';
+import { toDomeError } from './errorFactory.js';
 
 /**
  * Enhanced toDomeError function with service-specific context
@@ -62,13 +63,10 @@ export function createServiceErrorMiddleware(serviceName: string) {
         // Get logger from context or fallback
         const logger = c.get?.('logger') || getLogger();
 
-        // Get service-specific error handler
-        const toDomeError = createServiceErrorHandler(serviceName);
-
         // Convert error to DomeError
         const error = options.errorMapper
           ? options.errorMapper(err)
-          : toDomeError(err, 'Unhandled request error');
+          : toDomeError(err, serviceName, 'Unhandled request error');
 
         // Log error
         logger.error({

--- a/packages/common/src/utils/functionWrapper.ts
+++ b/packages/common/src/utils/functionWrapper.ts
@@ -1,6 +1,7 @@
-import { getLogger, logError, trackOperation } from '@dome/common';
+import { logError, trackOperation } from '@dome/common';
 import { withContext } from '@dome/common';
-import { toDomeError, DomeError } from '../errors/domeErrors.js';
+import { DomeError } from '../errors/domeErrors.js';
+import { toDomeError } from '../errors/errorFactory.js';
 
 // DomeError type re-exported for convenience
 
@@ -39,10 +40,11 @@ export function createServiceWrapper(serviceName: string) {
 
         // Convert to DomeError for consistent handling
         const domeError =
-          err && typeof err === 'object' && 'code' in err && 'message' in err
+          err instanceof DomeError
             ? err
             : toDomeError(
                 err,
+                serviceName,
                 `Error in ${serviceName} service${operation ? ` during ${operation}` : ''}`,
                 // Include original metadata as error context
                 meta as Record<string, any>,

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -9,6 +9,7 @@ import {
   NotFoundError,
   ForbiddenError,
   createServiceErrorHandler,
+  createServiceErrorMiddleware,
 } from '@dome/common/errors';
 import { getLogger, logError, withContext } from '@dome/common';
 import { authMetrics } from './utils/logging';
@@ -179,6 +180,7 @@ export default class Auth extends WorkerEntrypoint<Env> {
 
     // Initialize Hono App
     this.honoApp = new Hono<{ Bindings: Env }>().basePath('/auth');
+    this.honoApp.use('*', createServiceErrorMiddleware('auth')());
 
     // Hono Middleware
     this.honoApp.use('*', cors()); // Basic CORS for all routes
@@ -190,22 +192,7 @@ export default class Auth extends WorkerEntrypoint<Env> {
       logger.info({ status: c.res.status }, 'HTTP request processed');
     });
 
-    // Hono Error Handler
-    this.honoApp.onError((err, c) => {
-      const logger = getLogger();
-      logger.error({ error: err, path: c.req.path, method: c.req.method }, 'Hono API Error');
-      if (err instanceof BaseError) {
-        return c.json(
-          { error: { code: err.code, message: err.message, details: err.details } },
-          err.status as any,
-        );
-      }
-      const domeError = authToDomeError(err, 'An unexpected API error occurred');
-      return c.json(
-        { error: { code: domeError.code, message: domeError.message, details: domeError.details } },
-        domeError.statusCode as any,
-      );
-    });
+    // Hono Error Handler is provided by middleware
 
     // Define Hono HTTP Routes (details in next step)
     this.setupHttpRoutes();

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -9,6 +9,7 @@ import { WorkerEntrypoint } from 'cloudflare:workers';
 import { Hono } from 'hono';
 import { upgradeWebSocket } from 'hono/cloudflare-workers';
 import { getLogger, logError } from '@dome/common';
+import { createServiceErrorMiddleware } from '@dome/common/errors';
 import { createServices } from './services';
 import { createControllers } from './controllers';
 import { ChatBinding } from './client';
@@ -34,6 +35,7 @@ export default class Chat extends WorkerEntrypoint<Env> implements ChatBinding {
 
     // Create Hono app instance
     this.app = new Hono();
+    this.app.use('*', createServiceErrorMiddleware('chat')());
 
     this.app.post('/stream', async c => {
       // Parse once, Hono does *not* auto-parse JSON for you


### PR DESCRIPTION
## Summary
- update service wrapper to use new `toDomeError`
- simplify service error middleware
- install service error middleware in auth, chat and dome-api services

## Testing
- `just build-no-install`
- `just lint`
- `just test`
