### PR TITLE
Use new Dome error utilities

### DIFF
--- a/packages/common/src/errors/errorUtils.ts
+++ b/packages/common/src/errors/errorUtils.ts
@@ -3,6 +3,7 @@
  */
 import { getLogger } from '@dome/common';
 import { toDomeError as baseToDomeError, assertValid as originalAssertValid } from './domeErrors.js';
+import { toDomeError } from './errorFactory.js';
 
 /**
  * Enhanced toDomeError function with service-specific context
@@ -62,13 +63,10 @@ export function createServiceErrorMiddleware(serviceName: string) {
         // Get logger from context or fallback
         const logger = c.get?.('logger') || getLogger();
 
-        // Get service-specific error handler
-        const toDomeError = createServiceErrorHandler(serviceName);
-
         // Convert error to DomeError
         const error = options.errorMapper
           ? options.errorMapper(err)
-          : toDomeError(err, 'Unhandled request error');
+          : toDomeError(err, serviceName, 'Unhandled request error');
 
         // Log error
         logger.error({

--- a/packages/common/src/types/siloContent.ts
+++ b/packages/common/src/types/siloContent.ts
@@ -78,7 +78,7 @@ export const siloSimplePutSchema = z.object({
   category: ContentCategoryEnum.default('note'),
   mimeType: MimeTypeSchema.default('text/markdown'),
   content: z.union([z.string(), z.instanceof(ArrayBuffer)]).refine(
-    val => {
+    (val: string | ArrayBuffer) => {
       // Check if content is not empty
       if (typeof val === 'string') {
         return val.length > 0;

--- a/packages/common/src/utils/functionWrapper.ts
+++ b/packages/common/src/utils/functionWrapper.ts
@@ -1,6 +1,7 @@
-import { getLogger, logError, trackOperation } from '@dome/common';
+import { logError, trackOperation } from '@dome/common';
 import { withContext } from '@dome/common';
-import { toDomeError, DomeError } from '../errors/domeErrors.js';
+import { DomeError } from '../errors/domeErrors.js';
+import { toDomeError } from '../errors/errorFactory.js';
 
 // DomeError type re-exported for convenience
 
@@ -39,10 +40,11 @@ export function createServiceWrapper(serviceName: string) {
 
         // Convert to DomeError for consistent handling
         const domeError =
-          err && typeof err === 'object' && 'code' in err && 'message' in err
+          err instanceof DomeError
             ? err
             : toDomeError(
                 err,
+                serviceName,
                 `Error in ${serviceName} service${operation ? ` during ${operation}` : ''}`,
                 // Include original metadata as error context
                 meta as Record<string, any>,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,28 +231,6 @@ importers:
         specifier: ^5.0.4
         version: 5.8.3
 
-  packages/errors:
-    dependencies:
-      hono:
-        specifier: ^3.0.0
-        version: 3.12.12
-    devDependencies:
-      '@types/node':
-        specifier: ^18.0.0
-        version: 18.19.86
-      '@vitest/coverage-v8':
-        specifier: 0.34.6
-        version: 0.34.6(vitest@3.1.3(@types/debug@4.1.12)(@types/node@18.19.86)(lightningcss@1.29.2))
-      eslint:
-        specifier: ^8.0.0
-        version: 8.57.1
-      typescript:
-        specifier: ^5.0.0
-        version: 5.8.3
-      vitest:
-        specifier: ^3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@18.19.86)(lightningcss@1.29.2)
-
   packages/scripts:
     dependencies:
       '@dome/common':
@@ -298,9 +276,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@dome/silo':
         specifier: workspace:*
         version: link:../silo
@@ -393,9 +368,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@dome/todos':
         specifier: workspace:*
         version: link:../todos
@@ -481,9 +453,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@hono/zod-validator':
         specifier: ^0.1.8
         version: 0.1.11(hono@3.12.12)(zod@3.24.3)
@@ -639,9 +608,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@hono/zod-validator':
         specifier: ^0.1.8
         version: 0.1.11(hono@4.7.8)(zod@3.24.3)
@@ -737,9 +703,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@hono/zod-validator':
         specifier: ^0.1.11
         version: 0.1.11(hono@4.7.8)(zod@3.24.3)
@@ -10009,7 +9972,7 @@ snapshots:
       isstream: 0.1.2
       jsonwebtoken: 9.0.2
       mime-types: 2.1.35
-      retry-axios: 2.6.0(axios@1.9.0)
+      retry-axios: 2.6.0(axios@1.9.0(debug@4.4.0))
       tough-cookie: 4.1.4
     transitivePeerDependencies:
       - supports-color
@@ -11316,7 +11279,7 @@ snapshots:
       onetime: 7.0.0
       signal-exit: 4.1.0
 
-  retry-axios@2.6.0(axios@1.9.0):
+  retry-axios@2.6.0(axios@1.9.0(debug@4.4.0)):
     dependencies:
       axios: 1.9.0(debug@4.4.0)
 

--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -9,6 +9,7 @@ import {
   NotFoundError,
   ForbiddenError,
   createServiceErrorHandler,
+  createServiceErrorMiddleware,
 } from '@dome/common/errors';
 import { getLogger, logError, withContext } from '@dome/common';
 import { authMetrics } from './utils/logging';
@@ -179,6 +180,7 @@ export default class Auth extends WorkerEntrypoint<Env> {
 
     // Initialize Hono App
     this.honoApp = new Hono<{ Bindings: Env }>().basePath('/auth');
+    this.honoApp.use('*', createServiceErrorMiddleware('auth')());
 
     // Hono Middleware
     this.honoApp.use('*', cors()); // Basic CORS for all routes
@@ -190,22 +192,7 @@ export default class Auth extends WorkerEntrypoint<Env> {
       logger.info({ status: c.res.status }, 'HTTP request processed');
     });
 
-    // Hono Error Handler
-    this.honoApp.onError((err, c) => {
-      const logger = getLogger();
-      logger.error({ error: err, path: c.req.path, method: c.req.method }, 'Hono API Error');
-      if (err instanceof BaseError) {
-        return c.json(
-          { error: { code: err.code, message: err.message, details: err.details } },
-          err.status as any,
-        );
-      }
-      const domeError = authToDomeError(err, 'An unexpected API error occurred');
-      return c.json(
-        { error: { code: domeError.code, message: domeError.message, details: domeError.details } },
-        domeError.statusCode as any,
-      );
-    });
+    // Hono Error Handler is provided by middleware
 
     // Define Hono HTTP Routes (details in next step)
     this.setupHttpRoutes();

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -9,6 +9,7 @@ import { WorkerEntrypoint } from 'cloudflare:workers';
 import { Hono } from 'hono';
 import { upgradeWebSocket } from 'hono/cloudflare-workers';
 import { getLogger, logError } from '@dome/common';
+import { createServiceErrorMiddleware } from '@dome/common/errors';
 import { createServices } from './services';
 import { createControllers } from './controllers';
 import { ChatBinding } from './client';
@@ -34,6 +35,7 @@ export default class Chat extends WorkerEntrypoint<Env> implements ChatBinding {
 
     // Create Hono app instance
     this.app = new Hono();
+    this.app.use('*', createServiceErrorMiddleware('chat')());
 
     this.app.post('/stream', async c => {
       // Parse once, Hono does *not* auto-parse JSON for you


### PR DESCRIPTION
## Summary
- update service wrapper to use new `toDomeError`
- simplify service error middleware
- install service error middleware in auth, chat and dome-api services
- fix implicit any in Silo schema

## Testing
- `just build-no-install`
- `just lint`
- `just test`
