### PR TITLE
Refactor error handling utilities

### DIFF
--- a/packages/common/src/errors/errorUtils.ts
+++ b/packages/common/src/errors/errorUtils.ts
@@ -2,7 +2,7 @@
  * Error utilities that work with domeErrors module
  */
 import { getLogger } from '@dome/common';
-import { toDomeError as baseToDomeError, assertValid as originalAssertValid } from './domeErrors.js';
+import { toDomeError, assertValid as originalAssertValid } from './domeErrors.js';
 
 /**
  * Enhanced toDomeError function with service-specific context
@@ -19,7 +19,7 @@ export function createServiceErrorHandler(serviceName: string) {
     defaultMessage = `An unexpected error occurred in ${serviceName} service`,
     defaultDetails: Record<string, any> = {},
   ) {
-    return baseToDomeError(error, defaultMessage, {
+    return toDomeError(error, defaultMessage, {
       service: serviceName,
       ...defaultDetails,
     });
@@ -62,13 +62,10 @@ export function createServiceErrorMiddleware(serviceName: string) {
         // Get logger from context or fallback
         const logger = c.get?.('logger') || getLogger();
 
-        // Get service-specific error handler
-        const toDomeError = createServiceErrorHandler(serviceName);
-
         // Convert error to DomeError
         const error = options.errorMapper
           ? options.errorMapper(err)
-          : toDomeError(err, 'Unhandled request error');
+          : toDomeError(err, 'Unhandled request error', { service: serviceName });
 
         // Log error
         logger.error({

--- a/packages/common/src/utils/functionWrapper.ts
+++ b/packages/common/src/utils/functionWrapper.ts
@@ -38,15 +38,11 @@ export function createServiceWrapper(serviceName: string) {
       } catch (err) {
 
         // Convert to DomeError for consistent handling
-        const domeError =
-          err && typeof err === 'object' && 'code' in err && 'message' in err
-            ? err
-            : toDomeError(
-                err,
-                `Error in ${serviceName} service${operation ? ` during ${operation}` : ''}`,
-                // Include original metadata as error context
-                meta as Record<string, any>,
-              );
+        const domeError = toDomeError(
+          err,
+          `Error in ${serviceName} service${operation ? ` during ${operation}` : ''}`,
+          meta as Record<string, any>,
+        );
 
         // Log the error with structured format
         logError(

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -13,6 +13,7 @@ import { createServices } from './services';
 import { createControllers } from './controllers';
 import { ChatBinding } from './client';
 import { ChatRequest } from './types';
+import { createErrorMiddleware } from './utils/errors';
 
 export * from './client';
 
@@ -34,6 +35,7 @@ export default class Chat extends WorkerEntrypoint<Env> implements ChatBinding {
 
     // Create Hono app instance
     this.app = new Hono();
+    this.app.use('*', createErrorMiddleware());
 
     this.app.post('/stream', async c => {
       // Parse once, Hono does *not* auto-parse JSON for you

--- a/services/dome-api/src/index.ts
+++ b/services/dome-api/src/index.ts
@@ -10,12 +10,11 @@ import type { ServiceInfo } from '@dome/common';
 import { chatRequestSchema } from '@dome/chat/client';
 import {
   createRequestContextMiddleware,
-  createErrorMiddleware,
   responseHandlerMiddleware,
-  formatZodError,
   createDetailedLoggerMiddleware,
   updateContext,
 } from '@dome/common';
+import { errorHandler } from '@dome/common/errors';
 import { SupportedAuthProvider } from '@dome/auth/client'; // Import the enum
 import { authenticationMiddleware, AuthContext } from './middleware/authenticationMiddleware';
 import { buildAuthRouter } from './controllers/authController';
@@ -60,7 +59,7 @@ initMetrics({
 // Log application startup
 getLogger().info('Application starting');
 app.use('*', cors());
-app.use('*', createErrorMiddleware(formatZodError));
+app.use('*', errorHandler());
 // Replace simple auth with auth routes and protected route middleware
 app.use('*', responseHandlerMiddleware);
 


### PR DESCRIPTION
## Summary
- update service wrapper and error middleware to use `toDomeError`
- register error middleware for auth and chat services
- switch dome-api to errorHandler middleware

## Testing
- `just build-pkg packages/common` *(fails: EHOSTUNREACH)*
- `just lint`
- `just test`
