### PR TITLE
Refactor error utils and fix build

### DIFF
--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -4,10 +4,10 @@
   "private": true,
   "type": "module",
   "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.js"
     },

--- a/packages/common/src/errors/errorUtils.ts
+++ b/packages/common/src/errors/errorUtils.ts
@@ -62,13 +62,10 @@ export function createServiceErrorMiddleware(serviceName: string) {
         // Get logger from context or fallback
         const logger = c.get?.('logger') || getLogger();
 
-        // Get service-specific error handler
-        const toDomeError = createServiceErrorHandler(serviceName);
-
         // Convert error to DomeError
         const error = options.errorMapper
           ? options.errorMapper(err)
-          : toDomeError(err, 'Unhandled request error');
+          : baseToDomeError(err, 'Unhandled request error', { service: serviceName });
 
         // Log error
         logger.error({

--- a/packages/common/src/utils/functionWrapper.ts
+++ b/packages/common/src/utils/functionWrapper.ts
@@ -38,15 +38,11 @@ export function createServiceWrapper(serviceName: string) {
       } catch (err) {
 
         // Convert to DomeError for consistent handling
-        const domeError =
-          err && typeof err === 'object' && 'code' in err && 'message' in err
-            ? err
-            : toDomeError(
-                err,
-                `Error in ${serviceName} service${operation ? ` during ${operation}` : ''}`,
-                // Include original metadata as error context
-                meta as Record<string, any>,
-              );
+        const domeError = toDomeError(
+          err,
+          `Error in ${serviceName} service${operation ? ` during ${operation}` : ''}`,
+          meta as Record<string, any>,
+        );
 
         // Log the error with structured format
         logError(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,28 +231,6 @@ importers:
         specifier: ^5.0.4
         version: 5.8.3
 
-  packages/errors:
-    dependencies:
-      hono:
-        specifier: ^3.0.0
-        version: 3.12.12
-    devDependencies:
-      '@types/node':
-        specifier: ^18.0.0
-        version: 18.19.86
-      '@vitest/coverage-v8':
-        specifier: 0.34.6
-        version: 0.34.6(vitest@3.1.3(@types/debug@4.1.12)(@types/node@18.19.86)(lightningcss@1.29.2))
-      eslint:
-        specifier: ^8.0.0
-        version: 8.57.1
-      typescript:
-        specifier: ^5.0.0
-        version: 5.8.3
-      vitest:
-        specifier: ^3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@18.19.86)(lightningcss@1.29.2)
-
   packages/scripts:
     dependencies:
       '@dome/common':
@@ -298,9 +276,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@dome/silo':
         specifier: workspace:*
         version: link:../silo
@@ -393,9 +368,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@dome/todos':
         specifier: workspace:*
         version: link:../todos
@@ -481,9 +453,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@hono/zod-validator':
         specifier: ^0.1.8
         version: 0.1.11(hono@3.12.12)(zod@3.24.3)
@@ -639,9 +608,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@hono/zod-validator':
         specifier: ^0.1.8
         version: 0.1.11(hono@4.7.8)(zod@3.24.3)
@@ -737,9 +703,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@hono/zod-validator':
         specifier: ^0.1.11
         version: 0.1.11(hono@4.7.8)(zod@3.24.3)

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -13,6 +13,7 @@ import { createServices } from './services';
 import { createControllers } from './controllers';
 import { ChatBinding } from './client';
 import { ChatRequest } from './types';
+import { createErrorMiddleware } from './utils/errors';
 
 export * from './client';
 
@@ -34,6 +35,7 @@ export default class Chat extends WorkerEntrypoint<Env> implements ChatBinding {
 
     // Create Hono app instance
     this.app = new Hono();
+    this.app.use('*', createErrorMiddleware());
 
     this.app.post('/stream', async c => {
       // Parse once, Hono does *not* auto-parse JSON for you

--- a/services/constellation/tsconfig.json
+++ b/services/constellation/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "./dist",
     "target": "ES2020",
     "lib": ["ES2020"],
-    "module": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "types": ["./worker-configuration.d.ts", "@types/node"]
   },
   "include": ["src/**/*", "tests/**/*"]

--- a/services/dome-api/src/index.ts
+++ b/services/dome-api/src/index.ts
@@ -10,12 +10,11 @@ import type { ServiceInfo } from '@dome/common';
 import { chatRequestSchema } from '@dome/chat/client';
 import {
   createRequestContextMiddleware,
-  createErrorMiddleware,
   responseHandlerMiddleware,
-  formatZodError,
   createDetailedLoggerMiddleware,
   updateContext,
 } from '@dome/common';
+import { errorHandler } from '@dome/common/errors';
 import { SupportedAuthProvider } from '@dome/auth/client'; // Import the enum
 import { authenticationMiddleware, AuthContext } from './middleware/authenticationMiddleware';
 import { buildAuthRouter } from './controllers/authController';
@@ -60,7 +59,7 @@ initMetrics({
 // Log application startup
 getLogger().info('Application starting');
 app.use('*', cors());
-app.use('*', createErrorMiddleware(formatZodError));
+app.use('*', errorHandler());
 // Replace simple auth with auth routes and protected route middleware
 app.use('*', responseHandlerMiddleware);
 

--- a/services/silo/tsconfig.json
+++ b/services/silo/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "dist",
     "target": "ES2020",
     "lib": ["ES2020", "WebWorker"],
-    "module": "ES2020",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "skipLibCheck": true,
     "types": ["./worker-configuration.d.ts", "@types/node"]
   },


### PR DESCRIPTION
## Summary
- avoid recursion in `createServiceErrorHandler`
- update service error middleware to call core util
- fix `@dome/common` package types path
- enable NodeNext module resolution for Silo and Constellation services

## Testing
- `just build-no-install`
- `just lint`
- `just test`
