### PR TITLE
Refactor error handling utilities

### DIFF
--- a/packages/common/src/types/enrichedContent.ts
+++ b/packages/common/src/types/enrichedContent.ts
@@ -17,7 +17,7 @@ export const EnrichedMetadataSchema = z.object({
         dueDate: z.string().optional(), // ISO date if detected
         priority: z
           .string()
-          .transform(val => val.toLowerCase())
+          .transform((val: string) => val.toLowerCase())
           .pipe(z.enum(['high', 'medium', 'low']))
           .optional(),
       }),

--- a/packages/common/src/types/siloContent.ts
+++ b/packages/common/src/types/siloContent.ts
@@ -78,7 +78,7 @@ export const siloSimplePutSchema = z.object({
   category: ContentCategoryEnum.default('note'),
   mimeType: MimeTypeSchema.default('text/markdown'),
   content: z.union([z.string(), z.instanceof(ArrayBuffer)]).refine(
-    val => {
+    (val: string | ArrayBuffer) => {
       // Check if content is not empty
       if (typeof val === 'string') {
         return val.length > 0;

--- a/packages/common/src/utils/functionWrapper.ts
+++ b/packages/common/src/utils/functionWrapper.ts
@@ -38,15 +38,11 @@ export function createServiceWrapper(serviceName: string) {
       } catch (err) {
 
         // Convert to DomeError for consistent handling
-        const domeError =
-          err && typeof err === 'object' && 'code' in err && 'message' in err
-            ? err
-            : toDomeError(
-                err,
-                `Error in ${serviceName} service${operation ? ` during ${operation}` : ''}`,
-                // Include original metadata as error context
-                meta as Record<string, any>,
-              );
+        const domeError = toDomeError(
+          err,
+          `Error in ${serviceName} service${operation ? ` during ${operation}` : ''}`,
+          meta as Record<string, any>,
+        );
 
         // Log the error with structured format
         logError(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,28 +231,6 @@ importers:
         specifier: ^5.0.4
         version: 5.8.3
 
-  packages/errors:
-    dependencies:
-      hono:
-        specifier: ^3.0.0
-        version: 3.12.12
-    devDependencies:
-      '@types/node':
-        specifier: ^18.0.0
-        version: 18.19.86
-      '@vitest/coverage-v8':
-        specifier: 0.34.6
-        version: 0.34.6(vitest@3.1.3(@types/debug@4.1.12)(@types/node@18.19.86)(lightningcss@1.29.2))
-      eslint:
-        specifier: ^8.0.0
-        version: 8.57.1
-      typescript:
-        specifier: ^5.0.0
-        version: 5.8.3
-      vitest:
-        specifier: ^3.1.3
-        version: 3.1.3(@types/debug@4.1.12)(@types/node@18.19.86)(lightningcss@1.29.2)
-
   packages/scripts:
     dependencies:
       '@dome/common':
@@ -298,9 +276,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@dome/silo':
         specifier: workspace:*
         version: link:../silo
@@ -393,9 +368,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@dome/todos':
         specifier: workspace:*
         version: link:../todos
@@ -481,9 +453,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@hono/zod-validator':
         specifier: ^0.1.8
         version: 0.1.11(hono@3.12.12)(zod@3.24.3)
@@ -639,9 +608,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@hono/zod-validator':
         specifier: ^0.1.8
         version: 0.1.11(hono@4.7.8)(zod@3.24.3)
@@ -737,9 +703,6 @@ importers:
       '@dome/common':
         specifier: workspace:*
         version: link:../../packages/common
-      '@dome/errors':
-        specifier: workspace:*
-        version: link:../../packages/errors
       '@hono/zod-validator':
         specifier: ^0.1.11
         version: 0.1.11(hono@4.7.8)(zod@3.24.3)

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -13,6 +13,7 @@ import { createServices } from './services';
 import { createControllers } from './controllers';
 import { ChatBinding } from './client';
 import { ChatRequest } from './types';
+import { createErrorMiddleware } from './utils/errors';
 
 export * from './client';
 
@@ -34,6 +35,7 @@ export default class Chat extends WorkerEntrypoint<Env> implements ChatBinding {
 
     // Create Hono app instance
     this.app = new Hono();
+    this.app.use('*', createErrorMiddleware());
 
     this.app.post('/stream', async c => {
       // Parse once, Hono does *not* auto-parse JSON for you

--- a/services/dome-api/src/index.ts
+++ b/services/dome-api/src/index.ts
@@ -10,12 +10,11 @@ import type { ServiceInfo } from '@dome/common';
 import { chatRequestSchema } from '@dome/chat/client';
 import {
   createRequestContextMiddleware,
-  createErrorMiddleware,
   responseHandlerMiddleware,
-  formatZodError,
   createDetailedLoggerMiddleware,
   updateContext,
 } from '@dome/common';
+import { errorHandler } from '@dome/common/errors';
 import { SupportedAuthProvider } from '@dome/auth/client'; // Import the enum
 import { authenticationMiddleware, AuthContext } from './middleware/authenticationMiddleware';
 import { buildAuthRouter } from './controllers/authController';
@@ -60,7 +59,7 @@ initMetrics({
 // Log application startup
 getLogger().info('Application starting');
 app.use('*', cors());
-app.use('*', createErrorMiddleware(formatZodError));
+app.use('*', errorHandler());
 // Replace simple auth with auth routes and protected route middleware
 app.use('*', responseHandlerMiddleware);
 


### PR DESCRIPTION
## Summary
- update service wrapper and error middleware to use `toDomeError`
- register error middleware for auth and chat services
- switch dome-api to errorHandler middleware
- fix type annotations in common utilities

## Testing
- `just build-no-install`
- `just lint`
- `just test`
