### PR TITLE
Add common wrapServiceCall helper

### DIFF
--- a/packages/common/src/utils/index.ts
+++ b/packages/common/src/utils/index.ts
@@ -7,7 +7,7 @@
 export { formatZodError } from './zodUtils.js';
 
 // Function wrappers
-export { createServiceWrapper, createProcessChain } from './functionWrapper.js';
+export { createServiceWrapper, createProcessChain, wrapServiceCall } from './functionWrapper.js';
 
 // Content sanitization
 export {

--- a/services/constellation/src/index.ts
+++ b/services/constellation/src/index.ts
@@ -8,7 +8,7 @@ import {
   SiloContentItem,
 } from '@dome/common';
 
-import { withContext } from '@dome/common';
+import { wrapServiceCall } from '@dome/common';
 import {
   getLogger,
   logError,
@@ -52,33 +52,9 @@ const buildServices = (env: ServiceEnv) => ({
 });
 
 /**
- * Run a function with enhanced logging and error handling
- * @param meta Metadata for logging context
- * @param fn Function to execute
- * @returns Result of the function
+ * Helper to run service logic with standardized context and error handling.
  */
-const runWithLog = <T>(meta: Record<string, unknown>, fn: () => Promise<T>): Promise<T> =>
-  withContext(meta, async logger => {
-    try {
-      return await fn();
-    } catch (err) {
-      const requestId = typeof meta.requestId === 'string' ? meta.requestId : undefined;
-      const operation = typeof meta.op === 'string' ? meta.op : 'unknown_operation';
-
-      const errorContext = {
-        operation,
-        requestId,
-        service: 'constellation',
-        timestamp: new Date().toISOString(),
-        ...meta,
-      };
-
-      logError(err, `Unhandled error in ${operation}`, errorContext);
-
-      // Convert to a proper DomeError before rethrowing
-      throw toDomeError(err, `Error in ${operation}`, errorContext);
-    }
-  });
+const runWithLog = wrapServiceCall('constellation');
 
 /**
  * Send a failed message to the dead letter queue with enhanced error context

--- a/services/tsunami/src/utils/wrap.ts
+++ b/services/tsunami/src/utils/wrap.ts
@@ -1,11 +1,3 @@
-import { withContext, logError } from '@dome/common';
+import { wrapServiceCall } from '@dome/common';
 
-export const wrap = <T>(meta: Record<string, unknown>, fn: () => Promise<T>): Promise<T> =>
-  withContext(Object.assign({ service: 'tsunami' }, meta), async () => {
-    try {
-      return await fn();
-    } catch (err) {
-      logError(err, 'Unhandled error');
-      throw err;
-    }
-  });
+export const wrap = wrapServiceCall('tsunami');


### PR DESCRIPTION
## Summary
- add `wrapServiceCall` helper to `@dome/common`
- rework auth and constellation services to use the common wrapper
- simplify tsunami wrapper using the new helper

## Testing
- `just lint`
- `just build-no-install`
- `just test`
