### PR TITLE
Refactor services to use handler modules

### DIFF
--- a/services/ai-processor/src/handlers/queues.ts
+++ b/services/ai-processor/src/handlers/queues.ts
@@ -1,0 +1,100 @@
+import { NewContentQueue } from '@dome/silo/queues';
+import { toDomeError } from '@dome/common';
+import {
+  getLogger,
+  logError,
+  trackOperation,
+  aiProcessorMetrics,
+} from '../utils/logging';
+import type { NewContentMessage, ParsedMessageBatch } from '@dome/common';
+
+export async function handleQueue(this: any, batch: MessageBatch<NewContentMessage>) {
+  const batchId = crypto.randomUUID();
+
+  await trackOperation(
+    'process_message_batch',
+    async () => {
+      const startTime = Date.now();
+      const queueName = batch.queue;
+
+      let parsed: ParsedMessageBatch<NewContentMessage>;
+      try {
+        parsed = NewContentQueue.parseBatch(batch);
+      } catch (err) {
+        const domeError = toDomeError(err, 'Failed to parse message batch', {
+          batchId,
+          queueName,
+        });
+        logError(domeError, 'Invalid queue batch');
+        aiProcessorMetrics.counter('batch.errors', 1, {
+          queueName,
+          errorType: domeError.code,
+        });
+        throw domeError;
+      }
+
+      getLogger().info(
+        {
+          queueName,
+          batchId,
+          messageCount: parsed.messages.length,
+          firstMessageId: parsed.messages[0]?.id,
+          operation: 'queue',
+        },
+        'Processing queue batch',
+      );
+
+      aiProcessorMetrics.counter('batch.received', 1, { queueName });
+      aiProcessorMetrics.counter('messages.received', parsed.messages.length, { queueName });
+
+      let successCount = 0;
+      let errorCount = 0;
+
+      for (const message of parsed.messages) {
+        const messageRequestId = `${batchId}-${message.id}`;
+        try {
+          await this.services.processor.processMessage(message.body, messageRequestId);
+          successCount++;
+        } catch (error) {
+          errorCount++;
+          const domeError = toDomeError(error, 'Failed to process queue message', {
+            messageId: message.id,
+            contentId: message.body?.id,
+            batchId,
+            requestId: messageRequestId,
+          });
+
+          logError(domeError, 'Failed to process message from queue');
+          aiProcessorMetrics.counter('messages.errors', 1, {
+            queueName,
+            errorType: domeError.code,
+          });
+        }
+      }
+
+      const duration = Date.now() - startTime;
+      getLogger().info(
+        {
+          queueName,
+          batchId,
+          messageCount: parsed.messages.length,
+          successCount,
+          errorCount,
+          successRate: Math.round((successCount / parsed.messages.length) * 100),
+          durationMs: duration,
+          avgProcessingTimeMs: Math.round(duration / parsed.messages.length),
+          operation: 'queue',
+        },
+        'Completed processing queue batch',
+      );
+
+      aiProcessorMetrics.timing('batch.duration_ms', duration, { queueName });
+      aiProcessorMetrics.counter('batch.completed', 1, { queueName });
+      aiProcessorMetrics.counter('messages.processed', successCount, { queueName });
+      aiProcessorMetrics.gauge('batch.success_rate', successCount / parsed.messages.length, {
+        queueName,
+      });
+    },
+    { batchId, queueName: batch.queue, messageCount: batch.messages.length },
+  );
+}

--- a/services/ai-processor/src/handlers/rpc.ts
+++ b/services/ai-processor/src/handlers/rpc.ts
@@ -1,0 +1,224 @@
+import { z } from 'zod';
+import { NewContentMessage } from '@dome/common';
+import { toDomeError } from '@dome/common';
+import { domeAssertExists as assertExists } from '@dome/common/errors';
+import {
+  getLogger,
+  logError,
+  trackOperation,
+  aiProcessorMetrics,
+} from '../utils/logging';
+import { ReprocessRequestSchema } from '../types';
+
+export async function reprocess(this: any, data: z.infer<typeof ReprocessRequestSchema>) {
+  const requestId = crypto.randomUUID();
+
+  return trackOperation(
+    'reprocess_content',
+    async () => {
+      try {
+        const validatedData = ReprocessRequestSchema.parse(data);
+        const { id } = validatedData;
+
+        if (id) {
+          getLogger().info(
+            { requestId, id, operation: 'reprocess_content' },
+            'Reprocessing specific content by ID',
+          );
+
+          const result = await reprocessById.call(this, id, requestId);
+
+          aiProcessorMetrics.trackOperation('reprocess', true, {
+            type: 'by_id',
+            requestId,
+          });
+
+          return { success: true, reprocessed: result };
+        } else {
+          getLogger().info(
+            { requestId, operation: 'reprocess_content_batch' },
+            'Reprocessing all content with null or failed summary',
+          );
+
+          const result = await reprocessFailedContent.call(this, requestId);
+
+          aiProcessorMetrics.trackOperation('reprocess', true, {
+            type: 'all_failed',
+            requestId,
+            totalItems: String(result.total),
+            successfulItems: String(result.successful),
+          });
+
+          return { success: true, reprocessed: result };
+        }
+      } catch (error) {
+        const domeError = toDomeError(error, 'Error in reprocess operation', {
+          service: 'ai-processor',
+          operation: 'reprocess',
+          id: (data as any).id,
+          requestId,
+        });
+
+        logError(domeError, 'Failed to reprocess content');
+
+        aiProcessorMetrics.trackOperation('reprocess', false, {
+          errorType: domeError.code,
+          requestId,
+        });
+
+        throw domeError;
+      }
+    },
+    { requestId, id: (data as any).id },
+  );
+}
+
+export async function reprocessById(this: any, id: string, requestId: string): Promise<{ id: string; success: boolean }> {
+  return trackOperation(
+    'reprocess_by_id',
+    async () => {
+      try {
+        const metadata = await this.services.silo.getMetadataById(id);
+
+        assertExists(metadata, `Content with ID ${id} not found`, {
+          id,
+          operation: 'reprocessById',
+          requestId,
+        });
+
+        if (!metadata) {
+          logError(
+            new Error(`Metadata unexpectedly null after assertExists for ID: ${id}`),
+            'Unexpected null metadata',
+            { id, operation: 'reprocessById', requestId },
+          );
+          return { id, success: false };
+        }
+
+        const message: NewContentMessage = {
+          id: metadata.id,
+          userId: metadata.userId,
+          category: metadata.category,
+          mimeType: metadata.mimeType,
+        };
+
+        await this.services.processor.processMessage(message, requestId);
+
+        aiProcessorMetrics.trackOperation('reprocess_by_id', true, {
+          id,
+          requestId,
+          contentType: metadata.category || metadata.mimeType || 'unknown',
+        });
+
+        return { id, success: true };
+      } catch (error) {
+        const domeError = toDomeError(error, `Error reprocessing content with ID ${id}`, {
+          id,
+          operation: 'reprocessById',
+          requestId,
+        });
+
+        logError(domeError, `Failed to reprocess content ID: ${id}`);
+
+        aiProcessorMetrics.trackOperation('reprocess_by_id', false, {
+          id,
+          requestId,
+          errorType: domeError.code,
+        });
+
+        return { id, success: false };
+      }
+    },
+    { id, requestId },
+  );
+}
+
+export async function reprocessFailedContent(this: any, requestId: string): Promise<{ total: number; successful: number }> {
+  return trackOperation(
+    'reprocess_failed_content',
+    async () => {
+      try {
+        const failedContent = await this.services.silo.findContentWithFailedSummary();
+
+        getLogger().info(
+          { count: failedContent.length, requestId, operation: 'reprocessFailedContent' },
+          'Found content with failed summaries',
+        );
+
+        let successful = 0;
+        let errors = 0;
+
+        for (const content of failedContent) {
+          try {
+            const message: NewContentMessage = {
+              id: content.id,
+              userId: content.userId,
+              category: content.category,
+              mimeType: content.mimeType,
+            };
+
+            await this.services.processor.processMessage(message, requestId);
+            successful++;
+
+            if (successful % 10 === 0) {
+              getLogger().info(
+                {
+                  requestId,
+                  progress: `${successful}/${failedContent.length}`,
+                  percentComplete: Math.round((successful / failedContent.length) * 100),
+                  operation: 'reprocessFailedContent',
+                },
+                'Batch reprocessing progress',
+              );
+            }
+          } catch (error) {
+            errors++;
+            const domeError = toDomeError(error, `Error reprocessing content ID: ${content.id}`, {
+              id: content.id,
+              requestId,
+              operation: 'reprocessFailedContent',
+            });
+
+            logError(domeError, `Failed to reprocess content during batch operation`);
+          }
+        }
+
+        aiProcessorMetrics.trackOperation('reprocess_batch', true, {
+          totalItems: String(failedContent.length),
+          successfulItems: String(successful),
+          failedItems: String(errors),
+          requestId,
+        });
+
+        getLogger().info(
+          {
+            total: failedContent.length,
+            successful,
+            errors,
+            requestId,
+            successRate: failedContent.length > 0 ? Math.round((successful / failedContent.length) * 100) : 0,
+            operation: 'reprocessFailedContent',
+          },
+          'Completed batch reprocessing of failed content',
+        );
+
+        return { total: failedContent.length, successful };
+      } catch (error) {
+        const domeError = toDomeError(error, 'Error reprocessing failed content batch', {
+          requestId,
+          operation: 'reprocessFailedContent',
+        });
+
+        logError(domeError, 'Failed to reprocess content batch');
+
+        aiProcessorMetrics.trackOperation('reprocess_batch', false, {
+          errorType: domeError.code,
+          requestId,
+        });
+
+        return { total: 0, successful: 0 };
+      }
+    },
+    { requestId },
+  );
+}

--- a/services/ai-processor/src/index.ts
+++ b/services/ai-processor/src/index.ts
@@ -6,30 +6,21 @@
  */
 
 import { WorkerEntrypoint } from 'cloudflare:workers';
-import { withContext } from '@dome/common';
-import { metrics } from '@dome/common';
-import { toDomeError } from '@dome/common';
 import { createLlmService } from './services/llmService';
-import {
-  EnrichedContentMessage,
-  NewContentMessage,
-  ParsedMessageBatch,
-} from '@dome/common';
-import { NewContentQueue } from '@dome/silo/queues';
+import { NewContentMessage } from '@dome/common';
 import { SiloClient, SiloBinding } from '@dome/silo/client';
 import type { ServiceEnv } from './types';
 import { z } from 'zod';
-import { sendTodosToQueue } from './todos';
 import {
   getLogger,
   logError,
   trackOperation,
-  sanitizeForLogging,
   aiProcessorMetrics,
 } from './utils/logging';
 import { ReprocessResponseSchema, ReprocessRequestSchema } from './types';
-import { domeAssertExists as assertExists } from '@dome/common/errors';
 import { ContentProcessor } from './utils/processor';
+import * as rpcHandlers from './handlers/rpc';
+import * as queueHandlers from './handlers/queues';
 
 /**
  * Build service dependencies
@@ -70,76 +61,7 @@ export default class AiProcessor extends WorkerEntrypoint<ServiceEnv> {
    * @returns Result of reprocessing
    */
   async reprocess(data: z.infer<typeof ReprocessRequestSchema>) {
-    const requestId = crypto.randomUUID();
-
-    return trackOperation(
-      'reprocess_content',
-      async () => {
-        try {
-          // Validate input
-          const validatedData = ReprocessRequestSchema.parse(data);
-          const { id } = validatedData;
-
-          if (id) {
-            // Reprocess specific content by ID
-            getLogger().info(
-              {
-                requestId,
-                id,
-                operation: 'reprocess_content',
-              },
-              'Reprocessing specific content by ID',
-            );
-
-            const result = await this.reprocessById(id, requestId);
-
-            aiProcessorMetrics.trackOperation('reprocess', true, {
-              type: 'by_id',
-              requestId,
-            });
-
-            return { success: true, reprocessed: result };
-          } else {
-            // Reprocess all content with null or "Content processing failed" summary
-            getLogger().info(
-              {
-                requestId,
-                operation: 'reprocess_content_batch',
-              },
-              'Reprocessing all content with null or failed summary',
-            );
-
-            const result = await this.reprocessFailedContent(requestId);
-
-            aiProcessorMetrics.trackOperation('reprocess', true, {
-              type: 'all_failed',
-              requestId,
-              totalItems: String(result.total),
-              successfulItems: String(result.successful),
-            });
-
-            return { success: true, reprocessed: result };
-          }
-        } catch (error) {
-          const domeError = toDomeError(error, 'Error in reprocess operation', {
-            service: 'ai-processor',
-            operation: 'reprocess',
-            id: data.id,
-            requestId,
-          });
-
-          logError(domeError, 'Failed to reprocess content');
-
-          aiProcessorMetrics.trackOperation('reprocess', false, {
-            errorType: domeError.code,
-            requestId,
-          });
-
-          throw domeError;
-        }
-      },
-      { requestId, id: data.id },
-    );
+    return rpcHandlers.reprocess.call(this, data);
   }
 
   /**
@@ -153,77 +75,8 @@ export default class AiProcessor extends WorkerEntrypoint<ServiceEnv> {
    * @param requestId Request ID for correlation
    * @returns Result of reprocessing
    */
-  private async reprocessById(
-    id: string,
-    requestId: string,
-  ): Promise<{ id: string; success: boolean }> {
-    return trackOperation(
-      'reprocess_by_id',
-      async () => {
-        try {
-          // Get content metadata from Silo
-          const metadata = await this.services.silo.getMetadataById(id);
-
-          // Validate content exists
-          assertExists(metadata, `Content with ID ${id} not found`, {
-            id,
-            operation: 'reprocessById',
-            requestId,
-          });
-
-          // Add this check to satisfy TypeScript's null analysis after assertExists
-          if (!metadata) {
-            // This case should ideally not be reached if assertExists works as expected
-            // and throws an error. Logging it as an unexpected situation.
-            logError(
-              new Error(`Metadata unexpectedly null after assertExists for ID: ${id}`),
-              'Unexpected null metadata',
-              {
-                id,
-                operation: 'reprocessById',
-                requestId,
-              },
-            );
-            return { id, success: false };
-          }
-
-          // Create a new content message and process it
-          const message: NewContentMessage = {
-            id: metadata.id,
-            userId: metadata.userId,
-            category: metadata.category,
-            mimeType: metadata.mimeType,
-          };
-
-          await this.services.processor.processMessage(message, requestId);
-
-          aiProcessorMetrics.trackOperation('reprocess_by_id', true, {
-            id,
-            requestId,
-            contentType: metadata.category || metadata.mimeType || 'unknown',
-          });
-
-          return { id, success: true };
-        } catch (error) {
-          const domeError = toDomeError(error, `Error reprocessing content with ID ${id}`, {
-            id,
-            operation: 'reprocessById',
-            requestId,
-          });
-
-          logError(domeError, `Failed to reprocess content ID: ${id}`);
-
-          aiProcessorMetrics.trackOperation('reprocess_by_id', false, {
-            id,
-            requestId,
-            errorType: domeError.code,
-          });
-
-          return { id, success: false };
-        }
-      },
-      { id, requestId },
-    );
+  private async reprocessById(id: string, requestId: string): Promise<{ id: string; success: boolean }> {
+    return rpcHandlers.reprocessById.call(this, id, requestId);
   }
 
   /**
@@ -235,106 +88,8 @@ export default class AiProcessor extends WorkerEntrypoint<ServiceEnv> {
    * @param requestId Request ID for correlation
    * @returns Result statistics
    */
-  private async reprocessFailedContent(
-    requestId: string,
-  ): Promise<{ total: number; successful: number }> {
-    return trackOperation(
-      'reprocess_failed_content',
-      async () => {
-        try {
-          // Get all content with null or "Content processing failed" summary
-          const failedContent = await this.services.silo.findContentWithFailedSummary();
-
-          getLogger().info(
-            {
-              count: failedContent.length,
-              requestId,
-              operation: 'reprocessFailedContent',
-            },
-            'Found content with failed summaries',
-          );
-
-          let successful = 0;
-          let errors = 0;
-
-          // Process each failed content
-          for (const content of failedContent) {
-            try {
-              const message: NewContentMessage = {
-                id: content.id,
-                userId: content.userId,
-                category: content.category,
-                mimeType: content.mimeType,
-              };
-
-              await this.services.processor.processMessage(message, requestId);
-              successful++;
-
-              // Log progress periodically for long-running batch operations
-              if (successful % 10 === 0) {
-                getLogger().info(
-                  {
-                    requestId,
-                    progress: `${successful}/${failedContent.length}`,
-                    percentComplete: Math.round((successful / failedContent.length) * 100),
-                    operation: 'reprocessFailedContent',
-                  },
-                  'Batch reprocessing progress',
-                );
-              }
-            } catch (error) {
-              errors++;
-              const domeError = toDomeError(error, `Error reprocessing content ID: ${content.id}`, {
-                id: content.id,
-                requestId,
-                operation: 'reprocessFailedContent',
-              });
-
-              logError(domeError, `Failed to reprocess content during batch operation`);
-            }
-          }
-
-          aiProcessorMetrics.trackOperation('reprocess_batch', true, {
-            totalItems: String(failedContent.length),
-            successfulItems: String(successful),
-            failedItems: String(errors),
-            requestId,
-          });
-
-          getLogger().info(
-            {
-              total: failedContent.length,
-              successful,
-              errors,
-              requestId,
-              successRate:
-                failedContent.length > 0
-                  ? Math.round((successful / failedContent.length) * 100)
-                  : 0,
-              operation: 'reprocessFailedContent',
-            },
-            'Completed batch reprocessing of failed content',
-          );
-
-          return { total: failedContent.length, successful };
-        } catch (error) {
-          const domeError = toDomeError(error, 'Error reprocessing failed content batch', {
-            requestId,
-            operation: 'reprocessFailedContent',
-          });
-
-          logError(domeError, 'Failed to reprocess content batch');
-
-          aiProcessorMetrics.trackOperation('reprocess_batch', false, {
-            errorType: domeError.code,
-            requestId,
-          });
-
-          return { total: 0, successful: 0 };
-        }
-      },
-      { requestId },
-    );
+  private async reprocessFailedContent(requestId: string): Promise<{ total: number; successful: number }> {
+    return rpcHandlers.reprocessFailedContent.call(this, requestId);
   }
 
   /**
@@ -342,97 +97,6 @@ export default class AiProcessor extends WorkerEntrypoint<ServiceEnv> {
    * @param batch Batch of messages from the queue
    */
   async queue(batch: MessageBatch<NewContentMessage>) {
-    const batchId = crypto.randomUUID();
-
-    await trackOperation(
-      'process_message_batch',
-      async () => {
-        const startTime = Date.now();
-        const queueName = batch.queue;
-
-        let parsed: ParsedMessageBatch<NewContentMessage>;
-        try {
-          parsed = NewContentQueue.parseBatch(batch);
-        } catch (err) {
-          const domeError = toDomeError(err, 'Failed to parse message batch', {
-            batchId,
-            queueName,
-          });
-          logError(domeError, 'Invalid queue batch');
-          aiProcessorMetrics.counter('batch.errors', 1, {
-            queueName,
-            errorType: domeError.code,
-          });
-          throw domeError;
-        }
-
-        getLogger().info(
-          {
-            queueName,
-            batchId,
-            messageCount: parsed.messages.length,
-            firstMessageId: parsed.messages[0]?.id,
-            operation: 'queue',
-          },
-          'Processing queue batch',
-        );
-
-        // Track batch metrics
-        aiProcessorMetrics.counter('batch.received', 1, { queueName });
-        aiProcessorMetrics.counter('messages.received', parsed.messages.length, { queueName });
-
-        let successCount = 0;
-        let errorCount = 0;
-
-        // Process each message in the batch
-        for (const message of parsed.messages) {
-          const messageRequestId = `${batchId}-${message.id}`;
-          try {
-            await this.services.processor.processMessage(message.body, messageRequestId);
-            successCount++;
-          } catch (error) {
-            errorCount++;
-            const domeError = toDomeError(error, 'Failed to process queue message', {
-              messageId: message.id,
-              contentId: message.body?.id,
-              batchId,
-              requestId: messageRequestId,
-            });
-
-            logError(domeError, 'Failed to process message from queue');
-            aiProcessorMetrics.counter('messages.errors', 1, {
-              queueName,
-              errorType: domeError.code,
-            });
-          }
-        }
-
-        // Log batch completion with detailed statistics
-        const duration = Date.now() - startTime;
-        getLogger().info(
-          {
-            queueName,
-            batchId,
-            messageCount: parsed.messages.length,
-            successCount,
-            errorCount,
-            successRate: Math.round((successCount / parsed.messages.length) * 100),
-            durationMs: duration,
-            avgProcessingTimeMs: Math.round(duration / parsed.messages.length),
-            operation: 'queue',
-          },
-          'Completed processing queue batch',
-        );
-
-        // Track detailed batch metrics
-        aiProcessorMetrics.timing('batch.duration_ms', duration, { queueName });
-        aiProcessorMetrics.counter('batch.completed', 1, { queueName });
-        aiProcessorMetrics.counter('messages.processed', successCount, { queueName });
-        aiProcessorMetrics.gauge('batch.success_rate', successCount / parsed.messages.length, {
-          queueName,
-        });
-      },
-      { batchId, queueName: batch.queue, messageCount: batch.messages.length },
-    );
+    await queueHandlers.handleQueue.call(this, batch);
   }
 }

--- a/services/auth/src/controllers/routes.ts
+++ b/services/auth/src/controllers/routes.ts
@@ -1,0 +1,78 @@
+import { Hono } from 'hono';
+import { ValidationError } from '@dome/common/errors';
+import {
+  LoginResponse,
+  RegisterResponse,
+  ValidateTokenResponse,
+  LogoutResponse,
+  SupportedAuthProvider,
+} from '../types';
+import type { AuthService as UnifiedAuthService } from '../services/auth-service';
+import type { Env } from '../index';
+export function registerRoutes(app: Hono<{ Bindings: Env }>, service: UnifiedAuthService) {
+  // /login
+  app.post('/login', async c => {
+    const body = await c.req.json<{ providerName: string; credentials: Record<string, unknown> }>();
+    if (!body.providerName || !body.credentials) {
+      throw new ValidationError('providerName and credentials are required.');
+    }
+    const result = await service.login(body.providerName, body.credentials);
+    const response: LoginResponse = {
+      success: true,
+      user: result.user,
+      token: result.tokenInfo.token,
+      tokenType: result.tokenInfo.type,
+      expiresAt: result.tokenInfo.expiresAt,
+      provider: body.providerName,
+    };
+    return c.json(response);
+  });
+
+  // /register
+  app.post('/register', async c => {
+    const body = await c.req.json<{ providerName: string; registrationData: Record<string, unknown> }>();
+    if (!body.providerName || !body.registrationData) {
+      throw new ValidationError('providerName and registrationData are required.');
+    }
+    const result = await service.register(body.providerName, body.registrationData);
+    const response: RegisterResponse = {
+      success: true,
+      user: result.user,
+      token: result.tokenInfo.token,
+      tokenType: result.tokenInfo.type,
+      expiresAt: result.tokenInfo.expiresAt,
+      provider: body.providerName,
+    };
+    return c.json(response);
+  });
+
+  // /validate
+  app.post('/validate', async c => {
+    const body = await c.req.json<{ token: string; providerName?: string }>();
+    if (!body.token) {
+      throw new ValidationError('token is required.');
+    }
+    const providerEnum = body.providerName as SupportedAuthProvider | undefined;
+    const result = await service.validateToken(body.token, providerEnum);
+    const response: ValidateTokenResponse = {
+      success: true,
+      userId: result.userId,
+      provider: result.provider,
+      details: result.details,
+    };
+    return c.json(response);
+  });
+
+  // /logout
+  app.post('/logout', async c => {
+    const body = await c.req.json<{ providerName: string; token: string }>();
+    if (!body.providerName || !body.token) {
+      throw new ValidationError('providerName and token are required.');
+    }
+    await service.logout(body.token, body.providerName);
+    const response: LogoutResponse = { success: true };
+    return c.json(response);
+  });
+
+  app.get('/health', c => c.text('OK'));
+}

--- a/services/auth/src/controllers/rpc.ts
+++ b/services/auth/src/controllers/rpc.ts
@@ -1,0 +1,155 @@
+import { wrapServiceCall } from '@dome/common';
+import {
+  getLogger,
+} from '@dome/common';
+import { authMetrics } from '../utils/logging';
+import {
+  LoginResponse,
+  RegisterResponse,
+  ValidateTokenResponse,
+  LogoutResponse,
+  SupportedAuthProvider,
+} from '../types';
+
+const runRpcWithLog = wrapServiceCall('auth');
+
+export async function login(this: any, providerName: string, credentials: Record<string, unknown>): Promise<LoginResponse> {
+  const requestId = crypto.randomUUID();
+  return runRpcWithLog({ service: 'auth', op: 'rpcLogin', providerName, requestId }, async () => {
+    authMetrics.counter('rpc.login.requests', 1, { providerName });
+    getLogger().info(
+      { providerName, requestId, operation: 'rpcLogin' },
+      'Processing RPC login request',
+    );
+
+    const result = await this.unifiedAuthService.login(providerName, credentials);
+
+    authMetrics.counter('rpc.login.success', 1, { providerName });
+    getLogger().info(
+      { userId: result.user.id, providerName, requestId, operation: 'rpcLogin' },
+      'RPC Login successful',
+    );
+
+    return {
+      success: true,
+      user: result.user,
+      token: result.tokenInfo.token,
+      tokenType: result.tokenInfo.type,
+      expiresAt: result.tokenInfo.expiresAt,
+      provider: providerName,
+    };
+  });
+}
+
+export async function register(this: any, providerName: string, registrationData: Record<string, unknown>): Promise<RegisterResponse> {
+  const requestId = crypto.randomUUID();
+  return runRpcWithLog({ service: 'auth', op: 'rpcRegister', providerName, requestId }, async () => {
+    authMetrics.counter('rpc.register.requests', 1, { providerName });
+    getLogger().info(
+      { providerName, requestId, operation: 'rpcRegister' },
+      'Processing RPC register request',
+    );
+
+    const result = await this.unifiedAuthService.register(providerName, registrationData);
+
+    authMetrics.counter('rpc.register.success', 1, { providerName });
+    getLogger().info(
+      { userId: result.user.id, providerName, requestId, operation: 'rpcRegister' },
+      'RPC Registration successful',
+    );
+    return {
+      success: true,
+      user: result.user,
+      token: result.tokenInfo.token,
+      tokenType: result.tokenInfo.type,
+      expiresAt: result.tokenInfo.expiresAt,
+      provider: providerName,
+    };
+  });
+}
+
+export async function validateToken(this: any, token: string, providerName?: string): Promise<ValidateTokenResponse> {
+  const requestId = crypto.randomUUID();
+  return runRpcWithLog({ service: 'auth', op: 'rpcValidateToken', providerName, requestId }, async () => {
+    authMetrics.counter('rpc.validateToken.requests', 1, {
+      providerName: providerName || 'unknown',
+    });
+    getLogger().info(
+      { providerName, requestId, operation: 'rpcValidateToken' },
+      'Processing RPC validateToken request',
+    );
+
+    const providerEnum = providerName as SupportedAuthProvider | undefined;
+    const result = await this.unifiedAuthService.validateToken(token, providerEnum);
+
+    authMetrics.counter('rpc.validateToken.success', 1, {
+      providerName: providerName || 'unknown',
+    });
+    getLogger().info(
+      {
+        userId: result.userId,
+        provider: result.provider,
+        requestId,
+        operation: 'rpcValidateToken',
+      },
+      'RPC Token validation successful',
+    );
+
+    return {
+      success: true,
+      userId: result.userId,
+      provider: result.provider,
+      details: result.details,
+      user: result.user,
+    };
+  });
+}
+
+export async function logout(this: any, providerName: string, token: string): Promise<LogoutResponse> {
+  const requestId = crypto.randomUUID();
+  return runRpcWithLog({ service: 'auth', op: 'rpcLogout', providerName, requestId }, async () => {
+    authMetrics.counter('rpc.logout.requests', 1, { providerName });
+    getLogger().info(
+      { providerName, requestId, operation: 'rpcLogout' },
+      'Processing RPC logout request',
+    );
+
+    await this.unifiedAuthService.logout(token, providerName);
+
+    authMetrics.counter('rpc.logout.success', 1, { providerName });
+    getLogger().info(
+      { providerName, requestId, operation: 'rpcLogout' },
+      'RPC Logout successful',
+    );
+    return { success: true };
+  });
+}
+
+export async function refreshToken(this: any, refreshToken: string): Promise<LoginResponse> {
+  const requestId = crypto.randomUUID();
+  return runRpcWithLog({ service: 'auth', op: 'rpcRefresh', requestId }, async () => {
+    authMetrics.counter('rpc.refresh.requests', 1);
+    getLogger().info(
+      { requestId, operation: 'rpcRefresh' },
+      'Processing RPC refreshToken request',
+    );
+
+    const result = await this.unifiedAuthService.refreshTokens(refreshToken);
+
+    authMetrics.counter('rpc.refresh.success', 1);
+    getLogger().info(
+      { requestId, userId: result.user.id, operation: 'rpcRefresh' },
+      'Token refresh successful',
+    );
+
+    return {
+      success: true,
+      user: result.user,
+      token: result.accessToken,
+      refreshToken: result.refreshToken,
+      tokenType: 'Bearer',
+      expiresAt: result.expiresAt,
+      provider: 'refresh',
+    } as any;
+  });
+}

--- a/services/constellation/src/handlers/queues.ts
+++ b/services/constellation/src/handlers/queues.ts
@@ -1,0 +1,64 @@
+import { NewContentQueue } from '@dome/silo/queues';
+import { ParsedMessageBatch, NewContentMessage } from '@dome/common';
+import { toDomeError } from '../utils/errors';
+import {
+  getLogger,
+  logError,
+  trackOperation,
+  constellationMetrics as metrics,
+} from '../utils/logging';
+import { wrapServiceCall } from '@dome/common';
+import type { MessageBatch } from '@cloudflare/workers-types/experimental';
+
+const runWithLog = wrapServiceCall('constellation');
+
+export async function handleQueue(this: any, batch: MessageBatch<Record<string, unknown>>) {
+  const batchId = crypto.randomUUID();
+
+  await runWithLog(
+    {
+      service: 'constellation',
+      op: 'queue',
+      size: batch.messages.length,
+      batchRequestId: batchId,
+      ...this.env,
+    },
+    async () => {
+      const startTime = Date.now();
+      metrics.gauge('queue.batch_size', batch.messages.length);
+      metrics.counter('queue.batches_received', 1);
+
+      let parsed: ParsedMessageBatch<NewContentMessage>;
+      try {
+        parsed = NewContentQueue.parseBatch(batch);
+      } catch (err) {
+        const domeError = toDomeError(err, 'Failed to parse message batch', {
+          batchId,
+          queueName: batch.queue,
+        });
+        logError(domeError, 'Invalid queue batch');
+        metrics.counter('queue.parse_errors', 1);
+        throw domeError;
+      }
+
+      getLogger().info(
+        {
+          batchRequestId: batchId,
+          messageCount: parsed.messages.length,
+          queueName: batch.queue,
+          operation: 'queue',
+        },
+        `Processing queue batch with ${parsed.messages.length} messages`,
+      );
+
+      if (parsed.messages.length) {
+        const processed = await this.embedBatch(parsed.messages, this.env.EMBED_DEAD, batchId);
+        metrics.counter('queue.jobs_processed', processed);
+      }
+
+      const duration = Date.now() - startTime;
+      metrics.timing('queue.batch_processing_time', duration);
+      metrics.counter('queue.batches_completed', 1);
+    },
+  );
+}

--- a/services/constellation/src/handlers/rpc.ts
+++ b/services/constellation/src/handlers/rpc.ts
@@ -1,0 +1,271 @@
+import { VectorMeta, VectorSearchResult, ParsedQueueMessage, NewContentMessage, SiloContentItem } from '@dome/common';
+import { z } from 'zod';
+import { wrapServiceCall } from '@dome/common';
+import {
+  getLogger,
+  logError,
+  trackOperation,
+  constellationMetrics as metrics,
+} from '../utils/logging';
+import { toDomeError } from '../utils/errors';
+import { domeAssertValid as assertValid } from '@dome/common/errors';
+
+const runWithLog = wrapServiceCall('constellation');
+
+export async function embed(this: any, job: SiloContentItem) {
+  const requestId = crypto.randomUUID();
+  await runWithLog(
+    {
+      service: 'constellation',
+      op: 'embed',
+      content: job.id,
+      user: job.userId,
+      requestId,
+      ...this.env,
+    },
+    async () => {
+      try {
+        assertValid(!!job, 'Content item is required', { requestId });
+        assertValid(!!job.id, 'Content ID is required', {
+          requestId,
+          operation: 'embed',
+        });
+
+        metrics.counter('rpc.embed.requests', 1);
+
+        getLogger().info(
+          {
+            contentId: job.id,
+            userId: job.userId,
+            contentType: job.category || job.mimeType || 'unknown',
+            requestId,
+            operation: 'embed',
+          },
+          'Processing RPC embed request',
+        );
+
+        const msg: ParsedQueueMessage<NewContentMessage> = {
+          id: job.id,
+          timestamp: Date.now(),
+          body: {
+            id: job.id,
+            userId: job.userId,
+            category: job.category,
+            mimeType: job.mimeType,
+            createdAt: job.createdAt,
+          },
+        };
+
+        const processed = await this.embedBatch([msg], undefined, requestId);
+
+        metrics.counter('rpc.embed.success', 1);
+        metrics.trackOperation('rpc_embed', true, {
+          requestId,
+          contentId: job.id,
+        });
+
+        getLogger().info(
+          {
+            contentId: job.id,
+            processed,
+            success: processed === 1,
+            requestId,
+            operation: 'embed',
+          },
+          `RPC embed request ${processed === 1 ? 'succeeded' : 'failed'}`,
+        );
+      } catch (error) {
+        metrics.counter('rpc.embed.errors', 1);
+
+        const domeError = toDomeError(error, `Failed to embed content ID: ${job.id}`, {
+          contentId: job.id,
+          userId: job.userId,
+          requestId,
+          operation: 'embed',
+        });
+
+        logError(domeError, 'RPC embed request failed');
+
+        metrics.trackOperation('rpc_embed', false, {
+          requestId,
+          contentId: job.id,
+          errorType: domeError.code,
+        });
+
+        throw domeError;
+      }
+    },
+  );
+}
+
+export async function query(this: any, text: string, filter: Partial<VectorMeta>, topK = 10): Promise<VectorSearchResult[] | { error: unknown }> {
+  const requestId = crypto.randomUUID();
+
+  return runWithLog(
+    {
+      service: 'constellation',
+      op: 'query',
+      filter,
+      topK,
+      requestId,
+      ...this.env,
+    },
+    async () => {
+      try {
+        assertValid(typeof text === 'string', 'Text query is required', { requestId });
+        assertValid(text.trim().length > 0, 'Query text cannot be empty', { requestId });
+        assertValid(topK > 0 && topK <= 1000, 'topK must be between 1 and 1000', {
+          requestId,
+          providedTopK: topK,
+        });
+
+        metrics.counter('rpc.query.requests', 1);
+        metrics.gauge('rpc.query.text_length', text.length);
+
+        getLogger().info(
+          {
+            query: text,
+            filterKeys: Object.keys(filter),
+            topK,
+            requestId,
+            operation: 'query',
+          },
+          'Processing vector search query',
+        );
+
+        const { preprocessor, embedder, vectorize } = this.services;
+
+        const norm = preprocessor.normalize(text);
+
+        if (!norm) {
+          getLogger().warn(
+            { requestId, operation: 'query' },
+            'Normalization produced empty text, returning empty results',
+          );
+
+          metrics.counter('rpc.query.empty_norm', 1);
+          return [];
+        }
+
+        getLogger().debug(
+          {
+            requestId,
+            originalLength: text.length,
+            normalizedLength: norm.length,
+            operation: 'query',
+          },
+          'Successfully normalized query text',
+        );
+
+        const [queryVec] = await embedder.embed([norm]);
+
+        getLogger().debug(
+          {
+            requestId,
+            vectorLength: queryVec.length,
+            operation: 'query',
+          },
+          'Generated embedding vector for query',
+        );
+
+        const results = await vectorize.query(queryVec, filter, topK);
+
+        getLogger().info(
+          {
+            requestId,
+            resultCount: results.length,
+            topScore: results.length > 0 ? results[0].score : 0,
+            operation: 'query',
+          },
+          `Query returned ${results.length} results`,
+        );
+
+        metrics.counter('rpc.query.success', 1);
+        metrics.gauge('rpc.query.results', results.length);
+        metrics.trackOperation('vector_query', true, {
+          requestId,
+          resultCount: String(results.length),
+        });
+
+        return results;
+      } catch (error) {
+        metrics.counter('rpc.query.errors', 1);
+
+        const domeError = toDomeError(error, 'Vector query failed', {
+          requestId,
+          operation: 'query',
+          textLength: text?.length,
+          filterKeys: Object.keys(filter || {}),
+        });
+
+        logError(domeError, 'Vector query operation failed');
+
+        metrics.trackOperation('vector_query', false, {
+          requestId,
+          errorType: domeError.code,
+        });
+
+        return {
+          error: {
+            message: domeError.message,
+            code: domeError.code,
+            status: domeError.statusCode,
+          },
+        };
+      }
+    },
+  );
+}
+
+export async function stats(this: any) {
+  const requestId = crypto.randomUUID();
+
+  return runWithLog(
+    {
+      service: 'constellation',
+      op: 'stats',
+      requestId,
+      ...this.env,
+    },
+    async () => {
+      try {
+        metrics.counter('rpc.stats.requests', 1);
+
+        getLogger().info({ requestId, operation: 'stats' }, 'Fetching vector index statistics');
+
+        const stats = await this.services.vectorize.getStats();
+
+        metrics.counter('rpc.stats.success', 1);
+
+        getLogger().info(
+          {
+            requestId,
+            vectors: stats.vectors,
+            dimension: stats.dimension,
+            operation: 'stats',
+          },
+          'Successfully retrieved vector index statistics',
+        );
+
+        return stats;
+      } catch (error) {
+        metrics.counter('rpc.stats.errors', 1);
+
+        const domeError = toDomeError(error, 'Failed to retrieve vector index statistics', {
+          requestId,
+          operation: 'stats',
+        });
+
+        logError(domeError, 'Error getting vector index stats');
+
+        return {
+          error: {
+            message: domeError.message,
+            code: domeError.code,
+            status: domeError.statusCode,
+          },
+        };
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary
- refactor auth, ai-processor and constellation services to use dedicated handler files
- move HTTP route setup to `routes.ts`
- move RPC and queue logic into `handlers` modules
- keep worker indexes focused on bootstrapping

## Testing
- `just lint`
- `just build-no-install`
- `just test`
