### PR TITLE
Update error utils and middleware

### DIFF
--- a/packages/common/src/errors/errorUtils.ts
+++ b/packages/common/src/errors/errorUtils.ts
@@ -3,6 +3,7 @@
  */
 import { getLogger } from '@dome/common';
 import { toDomeError as baseToDomeError, assertValid as originalAssertValid } from './domeErrors.js';
+import { toDomeError } from './errorFactory.js';
 
 /**
  * Enhanced toDomeError function with service-specific context
@@ -62,13 +63,10 @@ export function createServiceErrorMiddleware(serviceName: string) {
         // Get logger from context or fallback
         const logger = c.get?.('logger') || getLogger();
 
-        // Get service-specific error handler
-        const toDomeError = createServiceErrorHandler(serviceName);
-
         // Convert error to DomeError
         const error = options.errorMapper
           ? options.errorMapper(err)
-          : toDomeError(err, 'Unhandled request error');
+          : toDomeError(err, serviceName, 'Unhandled request error');
 
         // Log error
         logger.error({

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -9,6 +9,7 @@ import { WorkerEntrypoint } from 'cloudflare:workers';
 import { Hono } from 'hono';
 import { upgradeWebSocket } from 'hono/cloudflare-workers';
 import { getLogger, logError } from '@dome/common';
+import { errorHandler } from '@dome/common/errors';
 import { createServices } from './services';
 import { createControllers } from './controllers';
 import { ChatBinding } from './client';
@@ -34,6 +35,7 @@ export default class Chat extends WorkerEntrypoint<Env> implements ChatBinding {
 
     // Create Hono app instance
     this.app = new Hono();
+    this.app.use('*', errorHandler());
 
     this.app.post('/stream', async c => {
       // Parse once, Hono does *not* auto-parse JSON for you

--- a/services/dome-api/src/index.ts
+++ b/services/dome-api/src/index.ts
@@ -16,6 +16,7 @@ import {
   createDetailedLoggerMiddleware,
   updateContext,
 } from '@dome/common';
+import { errorHandler } from '@dome/common/errors';
 import { SupportedAuthProvider } from '@dome/auth/client'; // Import the enum
 import { authenticationMiddleware, AuthContext } from './middleware/authenticationMiddleware';
 import { buildAuthRouter } from './controllers/authController';
@@ -61,6 +62,7 @@ initMetrics({
 getLogger().info('Application starting');
 app.use('*', cors());
 app.use('*', createErrorMiddleware(formatZodError));
+app.use('*', errorHandler());
 // Replace simple auth with auth routes and protected route middleware
 app.use('*', responseHandlerMiddleware);
 


### PR DESCRIPTION
## Summary
- use new `toDomeError` helper inside service wrapper and error middleware
- enable `errorHandler` in auth, chat and dome-api services

## Testing
- `npx just build-no-install`
- `npx just lint`
- `npx just test`
