### PR TITLE
Remove redundant error wrapping

### DIFF
--- a/services/ai-processor/src/handlers/queues.ts
+++ b/services/ai-processor/src/handlers/queues.ts
@@ -17,21 +17,7 @@ export async function handleQueue(this: any, batch: MessageBatch<NewContentMessa
       const startTime = Date.now();
       const queueName = batch.queue;
 
-      let parsed: ParsedMessageBatch<NewContentMessage>;
-      try {
-        parsed = NewContentQueue.parseBatch(batch);
-      } catch (err) {
-        const domeError = toDomeError(err, 'Failed to parse message batch', {
-          batchId,
-          queueName,
-        });
-        logError(domeError, 'Invalid queue batch');
-        aiProcessorMetrics.counter('batch.errors', 1, {
-          queueName,
-          errorType: domeError.code,
-        });
-        throw domeError;
-      }
+      const parsed: ParsedMessageBatch<NewContentMessage> = NewContentQueue.parseBatch(batch);
 
       getLogger().info(
         {

--- a/services/ai-processor/src/handlers/rpc.ts
+++ b/services/ai-processor/src/handlers/rpc.ts
@@ -16,8 +16,7 @@ export async function reprocess(this: any, data: z.infer<typeof ReprocessRequest
   return trackOperation(
     'reprocess_content',
     async () => {
-      try {
-        const validatedData = ReprocessRequestSchema.parse(data);
+      const validatedData = ReprocessRequestSchema.parse(data);
         const { id } = validatedData;
 
         if (id) {
@@ -51,23 +50,6 @@ export async function reprocess(this: any, data: z.infer<typeof ReprocessRequest
 
           return { success: true, reprocessed: result };
         }
-      } catch (error) {
-        const domeError = toDomeError(error, 'Error in reprocess operation', {
-          service: 'ai-processor',
-          operation: 'reprocess',
-          id: (data as any).id,
-          requestId,
-        });
-
-        logError(domeError, 'Failed to reprocess content');
-
-        aiProcessorMetrics.trackOperation('reprocess', false, {
-          errorType: domeError.code,
-          requestId,
-        });
-
-        throw domeError;
-      }
     },
     { requestId, id: (data as any).id },
   );

--- a/services/constellation/src/handlers/queues.ts
+++ b/services/constellation/src/handlers/queues.ts
@@ -28,18 +28,7 @@ export async function handleQueue(this: any, batch: MessageBatch<Record<string, 
       metrics.gauge('queue.batch_size', batch.messages.length);
       metrics.counter('queue.batches_received', 1);
 
-      let parsed: ParsedMessageBatch<NewContentMessage>;
-      try {
-        parsed = NewContentQueue.parseBatch(batch);
-      } catch (err) {
-        const domeError = toDomeError(err, 'Failed to parse message batch', {
-          batchId,
-          queueName: batch.queue,
-        });
-        logError(domeError, 'Invalid queue batch');
-        metrics.counter('queue.parse_errors', 1);
-        throw domeError;
-      }
+      const parsed: ParsedMessageBatch<NewContentMessage> = NewContentQueue.parseBatch(batch);
 
       getLogger().info(
         {


### PR DESCRIPTION
## Summary
- clean up local try/catch blocks that only wrapped errors
- rely on createServiceWrapper/trackOperation for logging and metrics

## Testing
- `just build-no-install`
- `just lint`
- `just test`
