### PR TITLE
Use wrapper for Silo controllers

### DIFF
--- a/services/silo/src/controllers/dlqController.ts
+++ b/services/silo/src/controllers/dlqController.ts
@@ -1,5 +1,4 @@
-import { getLogger, logError, metrics } from '@dome/common';
-import { toDomeError } from '@dome/common/errors';
+import { wrap } from '../utils/wrap';
 import { DLQService } from '../services/dlqService';
 import { DLQFilterOptions, DLQMessage, DLQStats } from '../types';
 
@@ -54,48 +53,31 @@ class DLQControllerImpl implements DLQController {
   constructor(private env: Env, private dlqService: DLQService) {}
 
   async getStats(): Promise<DLQStats> {
-    try {
-      return await this.dlqService.getDLQStats();
-    } catch (error) {
-      logError(error, 'Error getting DLQ stats');
-      throw toDomeError(error, 'Failed to get DLQ stats');
-    }
+    return wrap({ operation: 'getStats' }, () => this.dlqService.getDLQStats());
   }
 
   async getMessages(options?: DLQFilterOptions): Promise<DLQMessage<unknown>[]> {
-    try {
-      return await this.dlqService.getDLQMessages(options);
-    } catch (error) {
-      logError(error, 'Error getting DLQ messages');
-      throw toDomeError(error, 'Failed to get DLQ messages', { filterOptions: options });
-    }
+    return wrap({ operation: 'getMessages', filterOptions: options }, () =>
+      this.dlqService.getDLQMessages(options),
+    );
   }
 
   async reprocessMessage(id: string): Promise<string> {
-    try {
-      return await this.dlqService.reprocessMessage(id);
-    } catch (error) {
-      logError(error, 'Error reprocessing DLQ message');
-      throw toDomeError(error, 'Failed to reprocess DLQ message', { messageId: id });
-    }
+    return wrap({ operation: 'reprocessMessage', id }, () =>
+      this.dlqService.reprocessMessage(id),
+    );
   }
 
   async reprocessMessages(ids: string[]): Promise<Record<string, string>> {
-    try {
-      return await this.dlqService.reprocessMessages(ids);
-    } catch (error) {
-      logError(error, 'Error reprocessing DLQ messages');
-      throw toDomeError(error, 'Failed to reprocess DLQ messages', { messageIds: ids });
-    }
+    return wrap({ operation: 'reprocessMessages', messageIds: ids }, () =>
+      this.dlqService.reprocessMessages(ids),
+    );
   }
 
   async purgeMessages(options?: DLQFilterOptions): Promise<number> {
-    try {
-      return await this.dlqService.purgeMessages(options);
-    } catch (error) {
-      logError(error, 'Error purging DLQ messages');
-      throw toDomeError(error, 'Failed to purge DLQ messages', { filterOptions: options });
-    }
+    return wrap({ operation: 'purgeMessages', filterOptions: options }, () =>
+      this.dlqService.purgeMessages(options),
+    );
   }
 
   async sendToDLQ<T>(
@@ -108,15 +90,14 @@ class DLQControllerImpl implements DLQController {
       producerService?: string;
     },
   ): Promise<string> {
-    try {
-      return await this.dlqService.sendToDLQ(originalMessage, error, metadata);
-    } catch (error) {
-      logError(error, 'Error sending message to DLQ');
-      throw toDomeError(error, 'Failed to send message to DLQ', {
+    return wrap(
+      {
+        operation: 'sendToDLQ',
         queueName: metadata.queueName,
         messageId: metadata.messageId,
-      });
-    }
+      },
+      () => this.dlqService.sendToDLQ(originalMessage, error, metadata),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor `dlqController` to use the service wrapper
- refactor `contentController` to wrap operations instead of manual try/catch

## Testing
- `just lint`
- `just test`
