### PR TITLE
Use wrapper for Silo controllers

### DIFF
--- a/services/silo/src/controllers/contentController.ts
+++ b/services/silo/src/controllers/contentController.ts
@@ -1,5 +1,6 @@
-import { getLogger, logError, metrics } from '@dome/common';
-import { ValidationError, NotFoundError, UnauthorizedError, toDomeError } from '@dome/common/errors';
+import { getLogger, metrics } from '@dome/common';
+import { ValidationError, NotFoundError, UnauthorizedError } from '@dome/common/errors';
+import { wrap } from '../utils/wrap';
 import { ulid } from 'ulid';
 import { R2Service } from '../services/r2Service';
 import { MetadataService } from '../services/metadataService';
@@ -51,35 +52,34 @@ export class ContentController {
     const start = performance.now();
 
     try {
-      this.logInput('simplePut input data', input);
+      return await wrap({ operation: 'simplePut' }, async () => {
+        this.logInput('simplePut input data', input);
 
-      const id = input.id ?? ulid();
-      const userId = SiloService.normalizeUserId(input.userId ?? null);
-      const size = this.contentSize(input.content);
+        const id = input.id ?? ulid();
+        const userId = SiloService.normalizeUserId(input.userId ?? null);
+        const size = this.contentSize(input.content);
 
-      if (size > SIMPLE_PUT_MAX_SIZE) {
-        throw new ValidationError('Content size exceeds 1 MiB. Use createUpload for larger files.');
-      }
+        if (size > SIMPLE_PUT_MAX_SIZE) {
+          throw new ValidationError('Content size exceeds 1 MiB. Use createUpload for larger files.');
+        }
 
-      const category = input.category ?? 'note';
-      const mimeType = input.mimeType ?? this.deriveMimeType(category, input.content);
-      const r2Key = this.buildR2Key('content', id);
+        const category = input.category ?? 'note';
+        const mimeType = input.mimeType ?? this.deriveMimeType(category, input.content);
+        const r2Key = this.buildR2Key('content', id);
 
-      await this.r2Service.putObject(
-        r2Key,
-        input.content,
-        this.buildMetadata({ userId, category, mimeType, custom: input.metadata }),
-      );
+        await this.r2Service.putObject(
+          r2Key,
+          input.content,
+          this.buildMetadata({ userId, category, mimeType, custom: input.metadata }),
+        );
 
-      metrics.increment('silo.upload.bytes', size);
+        metrics.increment('silo.upload.bytes', size);
 
-      const createdAt = Math.floor(Date.now() / 1000);
-      logger.info({ id, category, mimeType, size }, 'Content stored successfully');
+        const createdAt = Math.floor(Date.now() / 1000);
+        logger.info({ id, category, mimeType, size }, 'Content stored successfully');
 
-      return { id, category, mimeType, size, createdAt };
-    } catch (error) {
-      this.handleError('simplePut', error);
-      throw toDomeError(error);
+        return { id, category, mimeType, size, createdAt };
+      });
     } finally {
       metrics.timing('silo.rpc.simplePut.latency_ms', performance.now() - start);
     }
@@ -93,8 +93,8 @@ export class ContentController {
     limit?: number;
     offset?: number;
   }): Promise<SiloContentBatch> {
-    try {
-      logger.info(params, 'batchGet called');
+    return wrap({ operation: 'batchGet' }, async () => {
+        logger.info(params, 'batchGet called');
 
       const { ids = [], userId = null, contentType, limit = 50, offset = 0 } = params;
 
@@ -141,14 +141,11 @@ export class ContentController {
           ? await this.metadataService.getContentCountForUser(userId, contentType)
           : metadataItems.length;
 
-      const items = Object.values(results);
-      logger.info({ itemsCount: items.length, total }, 'Returning batchGet results');
+        const items = Object.values(results);
+        logger.info({ itemsCount: items.length, total }, 'Returning batchGet results');
 
-      return { items, total, limit, offset };
-    } catch (error) {
-      this.handleError('batchGet', error);
-      throw toDomeError(error);
-    }
+        return { items, total, limit, offset };
+      });
   }
 
   /** Delete a content item (object + metadata) with ACL checks. */
@@ -183,8 +180,10 @@ export class ContentController {
 
   /** Process enriched content from AI processor */
   async processEnrichedContent(message: EnrichedContentMessage): Promise<void> {
-    try {
-      const { id, userId, metadata } = message;
+    return wrap(
+      { operation: 'processEnrichedContent', contentId: message.id },
+      async () => {
+        const { id, userId, metadata } = message;
 
       logger.info(
         {
@@ -202,19 +201,18 @@ export class ContentController {
         summary: metadata.summary,
       });
 
-      metrics.increment('silo.enriched_content.processed');
-      logger.info({ id, userId }, 'Content enriched successfully');
-    } catch (error) {
-      metrics.increment('silo.enriched_content.errors');
-      logError(error, 'Error processing enriched content', { messageId: message.id });
-      throw toDomeError(error, 'Failed to process enriched content', { contentId: message.id });
-    }
+        metrics.increment('silo.enriched_content.processed');
+        logger.info({ id, userId }, 'Content enriched successfully');
+      },
+    );
   }
 
   /** Process messages from the ingest queue */
   async processIngestMessage(message: SiloSimplePutInput): Promise<void> {
-    try {
-      const { content, metadata } = message;
+    return wrap(
+      { operation: 'processIngestMessage', messageId: message.id },
+      async () => {
+        const { content, metadata } = message;
       const id = message.id ?? ulid();
       const userId = SiloService.normalizeUserId(message.userId || null);
       const category = message.category || 'note';
@@ -240,15 +238,12 @@ export class ContentController {
       );
 
       // Update metrics
-      metrics.increment('silo.ingest_queue.processed');
+        metrics.increment('silo.ingest_queue.processed');
 
-      // The R2 event will trigger metadata creation via the silo-content-uploaded queue
-      logger.info({ id, userId, category, mimeType }, 'Content ingested successfully');
-    } catch (error) {
-      metrics.increment('silo.ingest_queue.errors');
-      logError(error, 'Error processing ingest queue message', { messageId: message.id });
-      throw toDomeError(error, 'Failed to process ingest queue message', { contentId: message.id });
-    }
+        // The R2 event will trigger metadata creation via the silo-content-uploaded queue
+        logger.info({ id, userId, category, mimeType }, 'Content ingested successfully');
+      },
+    );
   }
 
   /** Handle R2 PutObject events emitted via queue. */
@@ -258,8 +253,10 @@ export class ContentController {
       return null;
     }
 
-    try {
-      const { key } = event.object;
+    return wrap(
+      { operation: 'processR2Event', objectKey: event.object.key },
+      async () => {
+          const { key } = event.object;
       logger.info({ key }, 'Processing R2 PutObject event');
 
       const obj = await this.r2Service.headObject(key);
@@ -300,18 +297,15 @@ export class ContentController {
         metadata,
       });
 
-      metrics.increment('silo.r2.events.processed');
-      logger.info(
-        { id, key, category, mimeType, size: obj.size },
-        'R2 event processed successfully',
-      );
+          metrics.increment('silo.r2.events.processed');
+          logger.info(
+            { id, key, category, mimeType, size: obj.size },
+            'R2 event processed successfully',
+          );
 
-      return { id, category, mimeType, size: obj.size, createdAt };
-    } catch (error) {
-      metrics.increment('silo.r2.events.errors');
-      logError(error, 'Error processing R2 event', { event });
-      throw toDomeError(error, 'Failed to process R2 event', { objectKey: event.object.key });
-    }
+          return { id, category, mimeType, size: obj.size, createdAt };
+        },
+      );
   }
 
   /* ----------------------------------------------------------------------- */
@@ -416,11 +410,6 @@ export class ContentController {
     );
   }
 
-  private handleError(method: string, error: unknown) {
-    const domeError = toDomeError(error, `Error in Silo service during ${method}`);
-    logError(domeError, `Error in ${method}`);
-    metrics.increment('silo.rpc.errors', 1, { method });
-  }
 
   private async fetchAllMetadataForUser(
     userId: string | null,

--- a/services/silo/src/controllers/dlqController.ts
+++ b/services/silo/src/controllers/dlqController.ts
@@ -1,5 +1,4 @@
-import { getLogger, logError, metrics } from '@dome/common';
-import { toDomeError } from '@dome/common/errors';
+import { wrap } from '../utils/wrap';
 import { DLQService } from '../services/dlqService';
 import { DLQFilterOptions, DLQMessage, DLQStats } from '../types';
 
@@ -54,48 +53,31 @@ class DLQControllerImpl implements DLQController {
   constructor(private env: Env, private dlqService: DLQService) {}
 
   async getStats(): Promise<DLQStats> {
-    try {
-      return await this.dlqService.getDLQStats();
-    } catch (error) {
-      logError(error, 'Error getting DLQ stats');
-      throw toDomeError(error, 'Failed to get DLQ stats');
-    }
+    return wrap({ operation: 'getStats' }, () => this.dlqService.getDLQStats());
   }
 
   async getMessages(options?: DLQFilterOptions): Promise<DLQMessage<unknown>[]> {
-    try {
-      return await this.dlqService.getDLQMessages(options);
-    } catch (error) {
-      logError(error, 'Error getting DLQ messages');
-      throw toDomeError(error, 'Failed to get DLQ messages', { filterOptions: options });
-    }
+    return wrap({ operation: 'getMessages', filterOptions: options }, () =>
+      this.dlqService.getDLQMessages(options),
+    );
   }
 
   async reprocessMessage(id: string): Promise<string> {
-    try {
-      return await this.dlqService.reprocessMessage(id);
-    } catch (error) {
-      logError(error, 'Error reprocessing DLQ message');
-      throw toDomeError(error, 'Failed to reprocess DLQ message', { messageId: id });
-    }
+    return wrap({ operation: 'reprocessMessage', id }, () =>
+      this.dlqService.reprocessMessage(id),
+    );
   }
 
   async reprocessMessages(ids: string[]): Promise<Record<string, string>> {
-    try {
-      return await this.dlqService.reprocessMessages(ids);
-    } catch (error) {
-      logError(error, 'Error reprocessing DLQ messages');
-      throw toDomeError(error, 'Failed to reprocess DLQ messages', { messageIds: ids });
-    }
+    return wrap({ operation: 'reprocessMessages', messageIds: ids }, () =>
+      this.dlqService.reprocessMessages(ids),
+    );
   }
 
   async purgeMessages(options?: DLQFilterOptions): Promise<number> {
-    try {
-      return await this.dlqService.purgeMessages(options);
-    } catch (error) {
-      logError(error, 'Error purging DLQ messages');
-      throw toDomeError(error, 'Failed to purge DLQ messages', { filterOptions: options });
-    }
+    return wrap({ operation: 'purgeMessages', filterOptions: options }, () =>
+      this.dlqService.purgeMessages(options),
+    );
   }
 
   async sendToDLQ<T>(
@@ -108,15 +90,14 @@ class DLQControllerImpl implements DLQController {
       producerService?: string;
     },
   ): Promise<string> {
-    try {
-      return await this.dlqService.sendToDLQ(originalMessage, error, metadata);
-    } catch (error) {
-      logError(error, 'Error sending message to DLQ');
-      throw toDomeError(error, 'Failed to send message to DLQ', {
+    return wrap(
+      {
+        operation: 'sendToDLQ',
         queueName: metadata.queueName,
         messageId: metadata.messageId,
-      });
-    }
+      },
+      () => this.dlqService.sendToDLQ(originalMessage, error, metadata),
+    );
   }
 }
 


### PR DESCRIPTION
## Summary
- refactor `contentController` to rely on the service wrapper for error handling

## Testing
- `just build-no-install`
- `just lint`
- `just test`
