### PR TITLE
Add setup file to silo tests

### DIFF
--- a/services/silo/tests/setup.ts
+++ b/services/silo/tests/setup.ts
@@ -1,2 +1,7 @@
+// Minimal test setup
+export {};
 import { vi } from 'vitest';
-vi.mock('cloudflare:workers', () => ({ WorkerEntrypoint: class {} }));
+
+vi.mock('cloudflare:workers', () => ({
+  WorkerEntrypoint: class {},
+}));

--- a/services/silo/vitest.config.ts
+++ b/services/silo/vitest.config.ts
@@ -5,7 +5,7 @@ export default mergeConfig(
   baseConfig,
   defineConfig({
     test: {
-      setupFiles: ['tests/setup.ts'],
+      setupFiles: ['./tests/setup.ts'],
       coverage: {
         provider: 'v8',
         reporter: ['text', 'lcov', 'json', 'html'],


### PR DESCRIPTION
## Summary
- provide a local `tests/setup.ts` for the silo service that mocks `cloudflare:workers`
- reference the setup file from `vitest.config.ts`

## Testing
- `just test-pkg silo`