### PR TITLE
Add BaseWorker utilities and update services

### DIFF
--- a/docs/UTILITY_FUNCTIONS.md
+++ b/docs/UTILITY_FUNCTIONS.md
@@ -83,6 +83,32 @@ const user = await processUserRegistration(registrationData);
 - Simplifies complex workflows
 - Enforces input and output validation
 
+### 2.3 BaseWorker Utilities
+
+`BaseWorker` now exposes helper properties for common service patterns:
+
+```typescript
+class MyWorker extends BaseWorker<Env, Services> {
+  constructor(ctx: ExecutionContext, env: Env) {
+    super(ctx, env, buildServices, { serviceName: 'my-worker' });
+  }
+
+  async doSomething() {
+    return this.wrap({ operation: 'doSomething' }, async () => {
+      this.logger.info('doing work');
+      const res = await this.trackedFetch('https://api.example.com');
+      return res.ok;
+    });
+  }
+}
+```
+
+#### Key Features
+
+- `logger` property scoped to the service name
+- `wrap(meta, fn)` for standardized context and error handling
+- `trackedFetch` for external calls with automatic logging
+
 ## 3. Context Management
 
 ### 3.1 Context Propagation

--- a/packages/common/tests/BaseWorker.test.ts
+++ b/packages/common/tests/BaseWorker.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi } from 'vitest';
+import { BaseWorker } from '../src/service/BaseWorker';
+
+vi.mock('../src/utils/functionWrapper', async () => {
+  const actual = await vi.importActual<any>('../src/utils/functionWrapper');
+  return {
+    ...actual,
+    createServiceWrapper: vi.fn(() => async (_m: any, fn: () => Promise<any>) => fn()),
+  };
+});
+
+import { createServiceWrapper } from '../src/utils/functionWrapper';
+
+class TestWorker extends BaseWorker<any, Record<string, any>> {
+  public getServices() {
+    return this.services;
+  }
+}
+
+describe('BaseWorker', () => {
+  it('creates services lazily', () => {
+    const build = vi.fn(() => ({ a: 1 }));
+    const worker = new TestWorker({}, {}, build, { serviceName: 'test' });
+
+    expect(build).not.toHaveBeenCalled();
+    const s1 = worker.getServices();
+    expect(build).toHaveBeenCalledTimes(1);
+    const s2 = worker.getServices();
+    expect(build).toHaveBeenCalledTimes(1);
+    expect(s1).toBe(s2);
+  });
+
+  it('wrap delegates to createServiceWrapper', async () => {
+    const wrapperFn = vi.fn(async (_m: any, fn: () => Promise<any>) => fn());
+    (createServiceWrapper as unknown as vi.Mock).mockReturnValue(wrapperFn);
+
+    const worker = new TestWorker({}, {}, () => ({}), { serviceName: 'test' });
+    const result = await worker.wrap({ op: 'test' }, async () => 123);
+
+    expect(wrapperFn).toHaveBeenCalledWith({ op: 'test' }, expect.any(Function));
+    expect(result).toBe(123);
+  });
+});

--- a/services/chat/src/index.ts
+++ b/services/chat/src/index.ts
@@ -7,8 +7,6 @@
 
 import { BaseWorker } from '@dome/common';
 import { Hono } from 'hono';
-import { getLogger } from '@dome/common';
-import { wrap } from './utils/wrap';
 import { errorHandler } from '@dome/common/errors';
 import { createServices } from './services';
 import { createControllers } from './controllers';
@@ -23,7 +21,6 @@ export * from './client';
 export default class Chat extends BaseWorker<Env, ReturnType<typeof createServices>> implements ChatBinding {
   private controllers;
   private app: Hono;
-  private logger = getLogger().child({ component: 'Chat' });
 
   constructor(ctx: ExecutionContext, env: Env) {
     super(ctx, env, createServices, { serviceName: 'chat' });
@@ -69,7 +66,7 @@ export default class Chat extends BaseWorker<Env, ReturnType<typeof createServic
    * @returns Complete response with aggregated output
    */
   async generateChatMessage(request: ChatRequest): Promise<Response> {
-    return wrap(
+    return this.wrap(
       { operation: 'generateChatMessage', userId: request?.userId },
       () => this.controllers.chat.generateChatMessage(request),
     );
@@ -80,7 +77,7 @@ export default class Chat extends BaseWorker<Env, ReturnType<typeof createServic
    * @returns Checkpoint statistics
    */
   async getCheckpointStats(): Promise<any> {
-    return wrap(
+    return this.wrap(
       { operation: 'getCheckpointStats' },
       () => this.controllers.admin.getCheckpointStats(),
     );
@@ -91,7 +88,7 @@ export default class Chat extends BaseWorker<Env, ReturnType<typeof createServic
    * @returns Cleanup result
    */
   async cleanupCheckpoints(): Promise<{ deletedCount: number }> {
-    return wrap(
+    return this.wrap(
       { operation: 'cleanupCheckpoints' },
       () => this.controllers.admin.cleanupCheckpoints(),
     );
@@ -102,7 +99,7 @@ export default class Chat extends BaseWorker<Env, ReturnType<typeof createServic
    * @returns Data retention statistics
    */
   async getDataRetentionStats(): Promise<any> {
-    return wrap(
+    return this.wrap(
       { operation: 'getDataRetentionStats' },
       () => this.controllers.admin.getDataRetentionStats(),
     );
@@ -113,7 +110,7 @@ export default class Chat extends BaseWorker<Env, ReturnType<typeof createServic
    * @returns Cleanup result
    */
   async cleanupExpiredData(): Promise<any> {
-    return wrap(
+    return this.wrap(
       { operation: 'cleanupExpiredData' },
       () => this.controllers.admin.cleanupExpiredData(),
     );
@@ -125,7 +122,7 @@ export default class Chat extends BaseWorker<Env, ReturnType<typeof createServic
    * @returns Deletion result
    */
   async deleteUserData(userId: string): Promise<{ deletedCount: number }> {
-    return wrap(
+    return this.wrap(
       { operation: 'deleteUserData', userId },
       () => this.controllers.admin.deleteUserData(userId),
     );
@@ -143,7 +140,7 @@ export default class Chat extends BaseWorker<Env, ReturnType<typeof createServic
     dataCategory: string,
     request: { durationDays: number },
   ): Promise<{ success: boolean }> {
-    return wrap(
+    return this.wrap(
       { operation: 'recordConsent', userId, dataCategory },
       () => this.controllers.admin.recordConsent(userId, dataCategory, request),
     );


### PR DESCRIPTION
## Summary
- extend BaseWorker with logger, wrap and trackedFetch
- refactor Chat, Silo and Tsunami workers to use the new helpers
- test lazy service creation and wrap behaviour
- document BaseWorker helpers

## Testing
- `just lint`
- `just build`
- `just test`