### PR TITLE
Replace direct fetch calls with trackedFetch

### DIFF
--- a/services/chat/src/tools/webSearchTool.ts
+++ b/services/chat/src/tools/webSearchTool.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { getLogger } from '@dome/common';
+import { getLogger, trackedFetch } from '@dome/common';
 import { Document } from '../types';
 import { RetrievalTool, RetrievalInput } from '.';
 /* ------------------------------------------------------------------ */
@@ -48,12 +48,16 @@ async function fetchBraveSearch(
   url.searchParams.set('count', String(k));
   if (freshDays) url.searchParams.set('freshness', `${freshDays}d`);
 
-  const resp = await fetch(url.toString(), {
-    headers: {
-      Accept: 'application/json',
-      'X-Subscription-Token': apiKey,
+  const resp = await trackedFetch(
+    url.toString(),
+    {
+      headers: {
+        Accept: 'application/json',
+        'X-Subscription-Token': apiKey,
+      },
     },
-  });
+    { query: q, topK: k, freshDays },
+  );
   if (!resp.ok) throw new Error(`Search API error • ${resp.status}`);
 
   // TODO: fetch detailed info from the sites

--- a/services/tsunami/src/providers/notion/client.ts
+++ b/services/tsunami/src/providers/notion/client.ts
@@ -4,7 +4,7 @@
  * This client handles communication with the Notion API, including authentication,
  * rate limiting, and error handling.
  */
-import { getLogger, metrics } from '@dome/common';
+import { getLogger, metrics, trackedFetch, getRequestId } from '@dome/common';
 import { ServiceError } from '@dome/common/src/errors';
 import { NotionAuthManager } from './auth';
 
@@ -460,7 +460,11 @@ export class NotionClient {
           body: body ? JSON.stringify(body) : undefined,
         };
 
-        const response = await fetch(url, options);
+        const requestId = getRequestId();
+        const response = await trackedFetch(url, options, {
+          method,
+          requestId,
+        });
 
         // Handle rate limiting
         if (response.status === 429) {

--- a/services/tsunami/src/providers/website/robotsChecker.ts
+++ b/services/tsunami/src/providers/website/robotsChecker.ts
@@ -4,7 +4,7 @@
  * This class is responsible for checking robots.txt files and determining
  * if a URL is allowed to be crawled according to the robots.txt rules.
  */
-import { getLogger } from '@dome/common';
+import { getLogger, trackedFetch } from '@dome/common';
 
 export class RobotsChecker {
   private log = getLogger();
@@ -31,11 +31,15 @@ export class RobotsChecker {
 
     try {
       this.log.info({ robotsUrl }, 'Fetching robots.txt');
-      const response = await fetch(robotsUrl, {
-        headers: {
-          'User-Agent': this.userAgent,
+      const response = await trackedFetch(
+        robotsUrl,
+        {
+          headers: {
+            'User-Agent': this.userAgent,
+          },
         },
-      });
+        { robotsUrl },
+      );
 
       if (!response.ok) {
         if (response.status === 404) {

--- a/services/tsunami/src/providers/website/websiteCrawler.ts
+++ b/services/tsunami/src/providers/website/websiteCrawler.ts
@@ -4,7 +4,7 @@
  * This class is responsible for crawling websites and fetching pages.
  * It handles rate limiting, depth control, and URL filtering.
  */
-import { getLogger } from '@dome/common';
+import { getLogger, trackedFetch } from '@dome/common';
 import { RobotsChecker } from './robotsChecker';
 
 export class WebsiteCrawler {
@@ -248,11 +248,15 @@ export class WebsiteCrawler {
   private async fetchPage(url: string): Promise<CrawledPage> {
     this.log.debug({ url }, 'Fetching page');
 
-    const response = await fetch(url, {
-      headers: {
-        'User-Agent': this.userAgent,
+    const response = await trackedFetch(
+      url,
+      {
+        headers: {
+          'User-Agent': this.userAgent,
+        },
       },
-    });
+      { url },
+    );
 
     // Get content type and last modified date
     const contentType = response.headers.get('content-type') || 'text/html';


### PR DESCRIPTION
## Summary
- wrap all web search HTTP calls with `trackedFetch`
- refactor GitHub provider to use `trackedFetch`
- refactor Notion auth and client to log requests via `trackedFetch`
- update website provider components to use `trackedFetch`

## Testing
- `just lint`
- `just build-no-install`
- `just test`
