### PR TITLE
fix: cleanup sendToDLQ imports

### DIFF
--- a/services/silo/src/index.ts
+++ b/services/silo/src/index.ts
@@ -6,7 +6,7 @@
  */
 
 import { BaseWorker } from '@dome/common';
-import { getLogger, logError, metrics, trackOperation } from '@dome/common';
+import { getLogger, logError, metrics } from '@dome/common';
 import {
   DomeError,
   ValidationError,


### PR DESCRIPTION
## Summary
- remove leftover `trackOperation` import

## Testing
- `just build-no-install`
- `just lint`
- `just test`
