### PR TITLE
Refactor embed batch tracking

### DIFF
--- a/services/constellation/src/index.ts
+++ b/services/constellation/src/index.ts
@@ -12,7 +12,6 @@ import {
 import {
   getLogger,
   logError,
-  trackOperation,
   constellationMetrics as metrics,
 } from './utils/logging';
 import {
@@ -62,7 +61,8 @@ const buildServices = (env: ServiceEnv) => ({
  * @param payload Payload to send to dead letter queue
  * @param requestId Request ID for correlation
  */
-const sendToDeadLetter = async (
+async function sendToDeadLetter(
+  this: any,
   queue: Queue,
   payload: {
     err?: Error | string;
@@ -73,7 +73,7 @@ const sendToDeadLetter = async (
     timestamp?: number;
   },
   requestId: string = crypto.randomUUID(),
-) => {
+) {
   if (!queue) {
     logger.warn(
       {
@@ -91,8 +91,8 @@ const sendToDeadLetter = async (
     throw new Error(`Invalid payload format for sendToDeadLetter: ${JSON.stringify(payload)}`);
   }
 
-  return trackOperation(
-    'send_to_dlq',
+  return this.wrap(
+    { operation: 'send_to_dlq', requestId },
     async () => {
       logger.info(
         {
@@ -126,9 +126,8 @@ const sendToDeadLetter = async (
         'Successfully sent message to dead letter queue',
       );
     },
-    { requestId },
   );
-};
+}
 
 /* -------------------------------------------------------------------------- */
 /* worker                                                                     */
@@ -154,8 +153,8 @@ export default class Constellation extends BaseWorker<ServiceEnv, ReturnType<typ
     deadQueue?: DeadQueue,
     batchRequestId: string = crypto.randomUUID(),
   ): Promise<number> {
-    return trackOperation(
-      'embed_batch',
+    return this.wrap(
+      { operation: 'embed_batch', jobCount: messages.length, batchRequestId },
       async () => {
         const MAX_CHUNKS_PER_BATCH = 50;
         const MAX_TEXT_LENGTH = 100000;
@@ -182,8 +181,8 @@ export default class Constellation extends BaseWorker<ServiceEnv, ReturnType<typ
 
           let job!: SiloContentItem;
           try {
-            await trackOperation(
-              'process_content_job',
+            await this.wrap(
+              { ...jobContext, operation: 'process_content_job' },
               async () => {
                 const { silo, preprocessor, embedder, vectorize } = this.services;
 
@@ -260,7 +259,6 @@ export default class Constellation extends BaseWorker<ServiceEnv, ReturnType<typ
                 chunks.length = 0;
                 allVectors.length = 0;
               },
-              jobContext,
             );
           } catch (err) {
             const domeError = toDomeError(err, `Failed to embed content ID: ${msg.body.id}`, {
@@ -274,7 +272,8 @@ export default class Constellation extends BaseWorker<ServiceEnv, ReturnType<typ
             });
 
             if (deadQueue) {
-              await sendToDeadLetter(
+              await sendToDeadLetter.call(
+                this,
                 deadQueue,
                 {
                   err: domeError,
@@ -295,7 +294,6 @@ export default class Constellation extends BaseWorker<ServiceEnv, ReturnType<typ
         this.logBatchResults(batchRequestId, processed, messages.length, startTime);
         return processed;
       },
-      { jobCount: messages.length, batchRequestId },
     );
   }
 

--- a/services/constellation/tests/sendToDeadLetter.test.ts
+++ b/services/constellation/tests/sendToDeadLetter.test.ts
@@ -32,7 +32,7 @@ describe('sendToDeadLetter', () => {
   it('sends a serialized message', async () => {
     const queue = { send: vi.fn() } as any;
     const payload = { error: 'oops', originalMessage: { id: 1 } } as any;
-    await sendToDeadLetter(queue, payload, 'req1');
+    await sendToDeadLetter.call({ wrap: async (_m: any, fn: any) => fn() }, queue, payload, 'req1');
     expect(queue.send).toHaveBeenCalledTimes(1);
     const arg = queue.send.mock.calls[0][0];
     expect(typeof arg).toBe('string');
@@ -42,6 +42,8 @@ describe('sendToDeadLetter', () => {
   it('throws for invalid payload', async () => {
     const queue = { send: vi.fn() } as any;
     const badPayload = { foo: 'bar' } as any;
-    await expect(sendToDeadLetter(queue, badPayload, 'req2')).rejects.toThrow();
+    await expect(
+      sendToDeadLetter.call({ wrap: async (_m: any, fn: any) => fn() }, queue, badPayload, 'req2')
+    ).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- use `this.wrap` instead of `trackOperation` in `sendToDeadLetter`
- wrap batch embedding operations with `this.wrap`
- remove unused `trackOperation` import
- update tests to bind `sendToDeadLetter`

## Testing
- `just build-no-install`
- `just lint`
- `just test`
