### PR TITLE
Fix auth service to use BaseWorker

### DIFF
--- a/services/auth/src/index.ts
+++ b/services/auth/src/index.ts
@@ -1,4 +1,4 @@
-import { WorkerEntrypoint } from 'cloudflare:workers';
+import { BaseWorker } from '@dome/common';
 import { Hono } from 'hono';
 import { cors } from 'hono/cors';
 import { BaseError, createServiceErrorHandler, errorHandler } from '@dome/common/errors';
@@ -18,7 +18,6 @@ import { BaseAuthProvider } from './services/providers/base-auth-provider'; // C
 import { getAuthProvidersConfig } from './config/auth-config'; // Corrected path
 import { JwtTokenManager } from './services/token/token-manager'; // Use concrete class
 import { getTokenSettings } from './config/token-config'; // For JwtTokenManager
-import { DefaultProviderRegistry } from './services/providers/provider-registry'; // Use concrete class
 import { LocalAuthProvider } from './services/providers/local-auth-provider';
 import { PrivyAuthProvider } from './services/providers/privy-auth-provider';
 // import { GoogleAuthProvider } from './services/providers/google-auth-provider'; // Example for future
@@ -27,7 +26,7 @@ import { registerRoutes } from './controllers/routes';
 import * as rpcHandlers from './controllers/rpc';
 
 // Define Env if not already globally available or imported
-// This should match the Env used by WorkerEntrypoint<Env>
+// This should match the Env used by BaseWorker<Env>
 export interface Env {
   AUTH_DB: any; // D1Database, etc.
   // Expected environment variables for providers, JWT secrets, etc.
@@ -36,6 +35,69 @@ export interface Env {
 
 const authToDomeError = createServiceErrorHandler('auth');
 
+interface Services {
+  auth: UnifiedAuthService;
+}
+
+const buildServices = (env: Env): Services => {
+  const logger = getLogger();
+
+  if (!env.AUTH_DB) {
+    logger.error('AUTH_DB environment variable is not set.');
+    throw authToDomeError(
+      new Error('AUTH_DB is not configured.'),
+      'AUTH_DB configuration error',
+      { code: 'AUTH_CONFIG_ERROR', httpStatus: 500 },
+    );
+  }
+
+  const userManager = new UserManager();
+  const tokenManager = new JwtTokenManager(getTokenSettings(env));
+
+  const authProviderConfigs = getAuthProvidersConfig(env);
+  logger.info({ authProviderConfigs }, 'Loaded auth provider configurations.');
+
+  const activeProviders = new Map<SupportedAuthProvider, BaseAuthProvider>();
+
+  const localConfig = authProviderConfigs[SupportedAuthProvider.LOCAL];
+  if (localConfig?.isEnabled) {
+    logger.info(`Initializing LocalAuthProvider for ${SupportedAuthProvider.LOCAL}`);
+    activeProviders.set(
+      SupportedAuthProvider.LOCAL,
+      new LocalAuthProvider(localConfig, tokenManager, userManager, env),
+    );
+  }
+
+  if (env.AUTH_PRIVY_ENABLED === 'true' && env.PRIVY_APP_ID) {
+    logger.info('Initializing PrivyAuthProvider');
+    const privyConfig = { appId: env.PRIVY_APP_ID, jwksUri: env.PRIVY_JWKS_URI };
+    activeProviders.set(
+      SupportedAuthProvider.PRIVY,
+      new PrivyAuthProvider(privyConfig, tokenManager, userManager, env),
+    );
+  }
+
+  if (activeProviders.size === 0) {
+    logger.warn('No auth providers are enabled or configured.');
+  } else {
+    logger.info(
+      { enabledProviders: Array.from(activeProviders.keys()) },
+      'Auth providers initialized.',
+    );
+  }
+
+  const auth = new UnifiedAuthService({
+    userManager,
+    providerServices: activeProviders,
+    tokenManager,
+    env,
+  });
+
+  logger.info('UnifiedAuthService initialized.');
+
+  return { auth };
+};
+
 /**
  * Helper to run RPC methods with standardized context and error handling.
  */
@@ -43,113 +105,27 @@ const authToDomeError = createServiceErrorHandler('auth');
 /**
  * Auth service implementation
  *
- * This service provides authentication functionality as a WorkerEntrypoint
+ * This service provides authentication functionality as a BaseWorker
  * for RPC and an HTTP API via Hono.
  */
-export default class Auth extends WorkerEntrypoint<Env> {
+export default class Auth extends BaseWorker<Env, ReturnType<typeof buildServices>> {
   private unifiedAuthService: UnifiedAuthService;
   private honoApp: Hono<{ Bindings: Env }>;
 
   constructor(ctx: ExecutionContext, env: Env) {
-    super(ctx, env);
-    const logger = getLogger(); // Ensure logger is available
-    logger.info('Auth service constructor started.');
+    super(ctx, env, buildServices, { serviceName: 'auth' });
 
-    // Initialize UserManager and TokenManager
-    if (!env.AUTH_DB) {
-      logger.error('AUTH_DB environment variable is not set. UserManager cannot be initialized.');
-      // Use the authToDomeError helper
-      throw authToDomeError(
-        new Error('AUTH_DB is not configured.'),
-        'AUTH_DB configuration error',
-        { code: 'AUTH_CONFIG_ERROR', httpStatus: 500 },
-      );
-    }
-    const userManager = new UserManager(); // Corrected: UserManager takes no arguments
-    const tokenManager = new JwtTokenManager(getTokenSettings(env));
+    this.unifiedAuthService = this.services.auth;
 
-    // Get all provider configurations
-    const authProviderConfigs = getAuthProvidersConfig(env);
-    logger.info({ authProviderConfigs }, 'Loaded auth provider configurations.');
-
-    const activeProviders = new Map<SupportedAuthProvider, BaseAuthProvider>(); // Corrected Map type
-
-    // Initialize LocalAuthProvider (Email/Password)
-    const localConfig = authProviderConfigs[SupportedAuthProvider.LOCAL];
-    if (localConfig?.isEnabled) {
-      logger.info(`Initializing LocalAuthProvider for ${SupportedAuthProvider.LOCAL}`);
-      // Assuming LocalAuthProvider constructor is refactored: (config, tokenManager, userManager, env)
-      // and it calls super(tokenManager) and sets its providerName.
-      activeProviders.set(
-        SupportedAuthProvider.LOCAL,
-        new LocalAuthProvider(localConfig, tokenManager, userManager, env),
-      );
-    } else {
-      logger.info(`LocalAuthProvider (${SupportedAuthProvider.LOCAL}) is not enabled.`);
-    }
-
-    // Initialize PrivyAuthProvider
-    // Assuming Privy config is identified by env.PRIVY_APP_ID and a general enable flag
-    if (env.AUTH_PRIVY_ENABLED === 'true' && env.PRIVY_APP_ID) {
-      logger.info(`Initializing PrivyAuthProvider`);
-      const privyConfig = { appId: env.PRIVY_APP_ID, jwksUri: env.PRIVY_JWKS_URI }; // Construct config
-      // Assuming PrivyAuthProvider constructor is refactored: (config, tokenManager, userManager, env)
-      activeProviders.set(
-        SupportedAuthProvider.PRIVY,
-        new PrivyAuthProvider(privyConfig, tokenManager, userManager, env),
-      );
-    } else {
-      logger.info(`PrivyAuthProvider not enabled or PRIVY_APP_ID is missing.`);
-    }
-
-    // TODO: Add GoogleAuthProvider and GitHubAuthProvider initialization similarly
-    // const googleConfig = authProviderConfigs[SupportedAuthProvider.GOOGLE];
-    // if (googleConfig?.isEnabled && googleConfig.clientId && googleConfig.clientSecret) { ... }
-
-    // const githubConfig = authProviderConfigs[SupportedAuthProvider.GITHUB];
-    // if (githubConfig?.isEnabled && githubConfig.clientId && githubConfig.clientSecret) { ... }
-
-    if (activeProviders.size === 0) {
-      logger.warn(
-        'No auth providers are enabled or configured. Auth service may not function correctly.',
-      );
-    } else {
-      logger.info(
-        { enabledProviders: Array.from(activeProviders.keys()) },
-        'Auth providers initialized.',
-      );
-    }
-
-    // The ProviderRegistry is not directly passed to AuthService if AuthService expects a map.
-    // However, if AuthService was refactored to take ProviderRegistry:
-    // const providerRegistry = new DefaultProviderRegistry();
-    // activeProviders.forEach(provider => providerRegistry.registerProvider(provider));
-
-    // UnifiedAuthService (AuthService) expects dependencies as per its AuthServiceDependencies interface.
-    // Current AuthServiceDependencies: { userManager, providerServices: Map<string, BaseAuthProvider> }
-    // If AuthService needs tokenManager and env, its definition and dependencies interface must be updated.
-    this.unifiedAuthService = new UnifiedAuthService({
-      userManager,
-      providerServices: activeProviders, // Pass the map of providers
-      tokenManager, // Assuming AuthServiceDependencies is updated to accept this
-      env, // Assuming AuthServiceDependencies is updated to accept this
-    });
-    logger.info('UnifiedAuthService initialized.');
-
-    // Initialize Hono App
     this.honoApp = new Hono<{ Bindings: Env }>().basePath('/auth');
-
-    // Hono Middleware
-    this.honoApp.use('*', cors()); // Basic CORS for all routes
-    // Add a request logger middleware (simplified)
+    this.honoApp.use('*', cors());
     this.honoApp.use('*', async (c, next) => {
-      const logger = getLogger(); // Assuming getLogger works within Hono context via withContext or similar
+      const logger = getLogger();
       logger.info({ method: c.req.method, path: c.req.path }, 'Incoming HTTP request');
       await next();
       logger.info({ status: c.res.status }, 'HTTP request processed');
     });
 
-    // Error handler middleware
     this.honoApp.use('*', errorHandler({ errorMapper: authToDomeError }));
 
     registerRoutes(this.honoApp, this.unifiedAuthService);
@@ -215,9 +191,9 @@ export default class Auth extends WorkerEntrypoint<Env> {
     return rpcHandlers.refreshToken.call(this, refreshToken);
   }
 
-  // fetch method signature must match WorkerEntrypoint
+  // fetch method signature must match BaseWorker
   async fetch(request: Request): Promise<Response> {
-    // Env and ctx are available as this.env and this.ctx due to WorkerEntrypoint constructor
+    // Env and ctx are available as this.env and this.ctx due to BaseWorker constructor
     // The Hono app is initialized with this.env in the constructor.
     // Hono's fetch method takes (request, Env, ExecutionContext)
     // We need to ensure the context (logger) is properly propagated if Hono handlers rely on AsyncLocalStorage.


### PR DESCRIPTION
## Summary
- update Auth service to extend `BaseWorker`
- move initialization logic to a `buildServices` helper
- keep Hono routes and RPC methods intact

## Testing
- `just build-no-install`
- `just lint`
- `just test`
