### PR TITLE
feat: introduce loadEnv utility

### DIFF
--- a/docs/guides/development-workflow.md
+++ b/docs/guides/development-workflow.md
@@ -485,6 +485,13 @@ If you encounter issues with deployment:
    wrangler deploy --verbose
    ```
 
+### 12.4 Environment Variable Validation
+
+Services validate their configuration using `loadEnv` from `@dome/common`. Define
+a Zod schema in `services/<service>/src/config/env.ts` and call `loadEnv` in the
+service constructor. This replaces ad-hoc checks like `if (!env.AUTH_DB)` and
+handles comma-separated lists via schema transforms.
+
 ## 13. Conclusion
 
 Following this development workflow will help ensure a smooth and efficient development process for the Dome project. If you have any questions or suggestions for improving this workflow, please reach out to the team or submit a pull request to update this guide.

--- a/packages/common/src/config/env.ts
+++ b/packages/common/src/config/env.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import { formatZodError } from '../utils/zodUtils.js';
+
+/**
+ * Validate and load a service's environment variables.
+ *
+ * @param schema Zod schema describing the expected environment shape
+ * @param env Raw environment object
+ * @returns Parsed environment of type T
+ * @throws Error when validation fails
+ */
+export function loadEnv<T>(schema: z.ZodTypeAny, env: unknown): T {
+  const result = schema.safeParse(env);
+  if (!result.success) {
+    const formatted = formatZodError(result.error);
+    throw new Error(`Invalid environment: ${JSON.stringify(formatted)}`);
+  }
+  return result.data;
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -28,3 +28,5 @@ export * from './queue/index.js';
 
 // Service helpers
 export * from './service/BaseWorker.js';
+// Environment utilities
+export * from './config/env.js';

--- a/services/auth/src/config/auth-config.ts
+++ b/services/auth/src/config/auth-config.ts
@@ -21,7 +21,9 @@ import { SupportedAuthProvider, AuthProvidersConfig, ProviderConfig } from '../t
  * @param env - The environment object, typically context.env in a Cloudflare Worker.
  * @returns Configuration for all supported authentication providers.
  */
-export function getAuthProvidersConfig(env: any): AuthProvidersConfig {
+import type { AuthEnv } from './env';
+
+export function getAuthProvidersConfig(env: AuthEnv): AuthProvidersConfig {
   const config: AuthProvidersConfig = {};
 
   // Local Provider Configuration (Email/Password)
@@ -31,9 +33,7 @@ export function getAuthProvidersConfig(env: any): AuthProvidersConfig {
   };
 
   // Google Provider Configuration
-  const googleScopes = env.AUTH_GOOGLE_SCOPES
-    ? env.AUTH_GOOGLE_SCOPES.split(',')
-    : ['email', 'profile'];
+  const googleScopes = env.AUTH_GOOGLE_SCOPES ?? ['email', 'profile'];
 
   config[SupportedAuthProvider.GOOGLE] = {
     clientId: env.AUTH_GOOGLE_CLIENT_ID,
@@ -47,9 +47,7 @@ export function getAuthProvidersConfig(env: any): AuthProvidersConfig {
   };
 
   // GitHub Provider Configuration (Example structure)
-  const githubScopes = env.AUTH_GITHUB_SCOPES
-    ? env.AUTH_GITHUB_SCOPES.split(',')
-    : ['read:user', 'user:email'];
+  const githubScopes = env.AUTH_GITHUB_SCOPES ?? ['read:user', 'user:email'];
 
   config[SupportedAuthProvider.GITHUB] = {
     clientId: env.AUTH_GITHUB_CLIENT_ID,
@@ -75,7 +73,7 @@ export function getAuthProvidersConfig(env: any): AuthProvidersConfig {
  */
 export function getProviderConfig(
   providerName: SupportedAuthProvider,
-  env: any,
+  env: AuthEnv,
 ): ProviderConfig | undefined {
   const allConfigs = getAuthProvidersConfig(env);
   const config = allConfigs[providerName];

--- a/services/auth/src/config/env.ts
+++ b/services/auth/src/config/env.ts
@@ -1,0 +1,37 @@
+import { z } from 'zod';
+
+const csv = z
+  .string()
+  .transform(val => val.split(',').map(v => v.trim()).filter(Boolean));
+
+export const AuthEnvSchema = z.object({
+  AUTH_DB: z.any(),
+  AUTH_TOKENS: z.any().optional(),
+  ENVIRONMENT: z.string().optional(),
+  VERSION: z.string().optional(),
+
+  AUTH_PRIVY_ENABLED: z.string().optional(),
+  PRIVY_APP_ID: z.string().optional(),
+  PRIVY_JWKS_URI: z.string().optional(),
+
+  AUTH_GOOGLE_CLIENT_ID: z.string().optional(),
+  AUTH_GOOGLE_CLIENT_SECRET: z.string().optional(),
+  AUTH_GOOGLE_CALLBACK_URL: z.string().optional(),
+  AUTH_GOOGLE_SCOPES: csv.optional(),
+  AUTH_GOOGLE_ENABLED: z.string().optional(),
+
+  AUTH_GITHUB_CLIENT_ID: z.string().optional(),
+  AUTH_GITHUB_CLIENT_SECRET: z.string().optional(),
+  AUTH_GITHUB_CALLBACK_URL: z.string().optional(),
+  AUTH_GITHUB_SCOPES: csv.optional(),
+  AUTH_GITHUB_ENABLED: z.string().optional(),
+
+  JWT_ACCESS_TOKEN_SECRET: z.string(),
+  JWT_ACCESS_TOKEN_EXPIRES_IN: z.string().optional(),
+  JWT_REFRESH_TOKEN_SECRET: z.string(),
+  JWT_REFRESH_TOKEN_EXPIRES_IN: z.string().optional(),
+  JWT_ISSUER: z.string().optional(),
+  JWT_AUDIENCE: z.string().optional(),
+});
+
+export type AuthEnv = z.infer<typeof AuthEnvSchema>;

--- a/services/auth/src/config/token-config.ts
+++ b/services/auth/src/config/token-config.ts
@@ -46,25 +46,13 @@ const DEFAULT_AUDIENCE = 'dome-app';
  * @returns Token configuration settings.
  * @throws Error if essential secret keys are not defined in the environment.
  */
-export function getTokenSettings(env: any): TokenSettings {
-  const accessTokenSecret = env.JWT_ACCESS_TOKEN_SECRET;
-  const refreshTokenSecret = env.JWT_REFRESH_TOKEN_SECRET;
+import type { AuthEnv } from './env';
 
-  if (!accessTokenSecret) {
-    throw new Error(
-      'JWT_ACCESS_TOKEN_SECRET is not defined in environment variables. This is required.',
-    );
-  }
-  if (!refreshTokenSecret) {
-    throw new Error(
-      'JWT_REFRESH_TOKEN_SECRET is not defined in environment variables. This is required.',
-    );
-  }
-
+export function getTokenSettings(env: AuthEnv): TokenSettings {
   return {
-    accessTokenSecret,
+    accessTokenSecret: env.JWT_ACCESS_TOKEN_SECRET,
     accessTokenExpiresIn: env.JWT_ACCESS_TOKEN_EXPIRES_IN || DEFAULT_ACCESS_TOKEN_EXPIRES_IN,
-    refreshTokenSecret,
+    refreshTokenSecret: env.JWT_REFRESH_TOKEN_SECRET,
     refreshTokenExpiresIn: env.JWT_REFRESH_TOKEN_EXPIRES_IN || DEFAULT_REFRESH_TOKEN_EXPIRES_IN,
     issuer: env.JWT_ISSUER || DEFAULT_ISSUER,
     audience: env.JWT_AUDIENCE || DEFAULT_AUDIENCE,

--- a/services/auth/src/services/providers/local-auth-provider.ts
+++ b/services/auth/src/services/providers/local-auth-provider.ts
@@ -41,14 +41,6 @@ export class LocalAuthProvider extends BaseAuthProvider {
   }
 
   private getAuthContext() {
-    if (!this.env || !this.env.AUTH_DB) {
-      // Or handle this more gracefully, maybe throw a config error
-      console.error('AUTH_DB not found in environment provided to LocalAuthProvider');
-      throw new ServiceError('LocalAuthProvider not configured correctly with AUTH_DB.', {
-        service: 'auth',
-        code: 'PROVIDER_CONFIG_ERROR',
-      });
-    }
     return {
       env: this.env,
       db: this.env.AUTH_DB,

--- a/services/auth/src/services/providers/privy-auth-provider.ts
+++ b/services/auth/src/services/providers/privy-auth-provider.ts
@@ -56,13 +56,6 @@ export class PrivyAuthProvider extends BaseAuthProvider {
   }
 
   private getAuthContext() {
-    if (!this.env || !this.env.AUTH_DB) {
-      console.error('AUTH_DB not found in environment provided to PrivyAuthProvider');
-      throw new ServiceError('PrivyAuthProvider not configured correctly with AUTH_DB.', {
-        service: 'auth',
-        code: 'PROVIDER_CONFIG_ERROR',
-      });
-    }
     return {
       env: this.env,
       db: this.env.AUTH_DB,

--- a/services/silo/src/config/env.ts
+++ b/services/silo/src/config/env.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+export const SiloEnvSchema = z.object({
+  LOG_LEVEL: z.string(),
+  VERSION: z.string(),
+  ENVIRONMENT: z.string(),
+  BUCKET: z.any(),
+  DB: z.any(),
+  NEW_CONTENT_CONSTELLATION: z.any(),
+  NEW_CONTENT_AI: z.any(),
+  INGEST_DLQ: z.any().optional(),
+  SILO_INGEST_QUEUE: z.any().optional(),
+});
+
+export type SiloEnv = z.infer<typeof SiloEnvSchema>;

--- a/services/silo/src/controllers/contentController.ts
+++ b/services/silo/src/controllers/contentController.ts
@@ -7,6 +7,7 @@ import { MetadataService } from '../services/metadataService';
 import { QueueService } from '../services/queueService';
 import { SiloService } from '../services/siloService';
 import { R2Event } from '../types';
+import type { SiloEnv } from '../config/env';
 import {
   SiloContentMetadata,
   SiloSimplePutResponse,
@@ -36,7 +37,7 @@ const logger = getLogger();
 
 export class ContentController {
   constructor(
-    private readonly env: Env,
+    private readonly env: SiloEnv,
     private readonly r2Service: R2Service,
     private readonly metadataService: MetadataService,
     private readonly queueService: QueueService,
@@ -434,7 +435,7 @@ export class ContentController {
 // ---------------------------------------------------------------------------
 
 export function createContentController(
-  env: Env,
+  env: SiloEnv,
   r2Service: R2Service,
   metadataService: MetadataService,
   queueService: QueueService,

--- a/services/silo/src/controllers/dlqController.ts
+++ b/services/silo/src/controllers/dlqController.ts
@@ -49,8 +49,10 @@ export interface DLQController {
 /**
  * DLQ Controller implementation
  */
+import type { SiloEnv } from '../config/env';
+
 class DLQControllerImpl implements DLQController {
-  constructor(private env: Env, private dlqService: DLQService) {}
+  constructor(private env: SiloEnv, private dlqService: DLQService) {}
 
   async getStats(): Promise<DLQStats> {
     return wrap({ operation: 'getStats' }, () => this.dlqService.getDLQStats());
@@ -104,6 +106,6 @@ class DLQControllerImpl implements DLQController {
 /**
  * Create a new DLQ controller
  */
-export function createDLQController(env: Env, dlqService: DLQService): DLQController {
+export function createDLQController(env: SiloEnv, dlqService: DLQService): DLQController {
   return new DLQControllerImpl(env, dlqService);
 }

--- a/services/silo/src/index.ts
+++ b/services/silo/src/index.ts
@@ -38,15 +38,18 @@ import {
   IngestDlqQueue,
   R2EventQueue,
 } from './queues';
+import { loadEnv } from '@dome/common/config/env';
+import { SiloEnvSchema, SiloEnv } from './config/env';
 export * from './client';
 
 /**
  * Silo service main class
  */
-export default class Silo extends BaseWorker<Env, Services> implements SiloBinding {
+export default class Silo extends BaseWorker<SiloEnv, Services> implements SiloBinding {
 
-  constructor(ctx: ExecutionContext, env: Env) {
-    super(ctx, env, createServices, { serviceName: 'silo' });
+  constructor(ctx: ExecutionContext, env: unknown) {
+    const parsedEnv = loadEnv<SiloEnv>(SiloEnvSchema, env);
+    super(ctx, parsedEnv, createServices, { serviceName: 'silo' });
   }
 
   /**

--- a/services/silo/src/services/dlqService.ts
+++ b/services/silo/src/services/dlqService.ts
@@ -18,6 +18,7 @@ import { drizzle } from 'drizzle-orm/d1';
 import { eq, and, sql, desc, count } from 'drizzle-orm';
 import { dlqMetadata } from '../db/schema';
 import { DLQFilterOptions, DLQMessage, DLQStats } from '../types';
+import type { SiloEnv } from '../config/env';
 import { siloSimplePutSchema } from '@dome/common';
 import { IngestQueue, IngestDlqQueue } from '../queues';
 import { z } from 'zod';
@@ -84,7 +85,7 @@ export class DLQServiceImpl implements DLQService {
   private ingestQueue?: IngestQueue;
   private ingestDlq?: IngestDlqQueue;
 
-  constructor(private env: Env) {
+  constructor(private env: SiloEnv) {
     this.db = drizzle(env.DB);
     this.ingestQueue = env.SILO_INGEST_QUEUE ? new IngestQueue(env.SILO_INGEST_QUEUE) : undefined;
     this.ingestDlq = env.INGEST_DLQ ? new IngestDlqQueue(env.INGEST_DLQ) : undefined;
@@ -1031,6 +1032,6 @@ export class DLQServiceImpl implements DLQService {
 /**
  * Create a new DLQ service
  */
-export function createDLQService(env: Env): DLQService {
+export function createDLQService(env: SiloEnv): DLQService {
   return new DLQServiceImpl(env);
 }

--- a/services/silo/src/services/index.ts
+++ b/services/silo/src/services/index.ts
@@ -5,6 +5,7 @@ import { createDLQService } from './dlqService';
 import { createContentController, ContentController } from '../controllers/contentController';
 import { createStatsController, StatsController } from '../controllers/statsController';
 import { createDLQController, DLQController } from '../controllers/dlqController';
+import type { SiloEnv } from '../config/env';
 
 /**
  * Service container interface
@@ -19,7 +20,7 @@ export interface Services {
 /**
  * Create and initialize all services
  */
-export function createServices(env: Env): Services {
+export function createServices(env: SiloEnv): Services {
   // Create service wrappers around external services
   const r2Service = createR2Service(env);
   const metadataService = createMetadataService(env);

--- a/services/silo/src/services/metadataService.ts
+++ b/services/silo/src/services/metadataService.ts
@@ -4,6 +4,7 @@ import { eq, and, desc, count, sum, or, isNull, inArray } from 'drizzle-orm';
 import { contents } from '../db/schema';
 import { SiloContentMetadata, SiloStatsResponse, PUBLIC_USER_ID } from '@dome/common';
 import { SiloService } from './siloService';
+import type { SiloEnv } from '../config/env';
 
 /**
  * MetadataService - A wrapper around D1 for content metadata operations
@@ -12,7 +13,7 @@ import { SiloService } from './siloService';
 export class MetadataService {
   private db: ReturnType<typeof drizzle>;
 
-  constructor(private env: Env) {
+  constructor(private env: SiloEnv) {
     this.db = drizzle(env.DB);
   }
 
@@ -442,6 +443,6 @@ export class MetadataService {
   }
 }
 
-export function createMetadataService(env: Env): MetadataService {
+export function createMetadataService(env: SiloEnv): MetadataService {
   return new MetadataService(env);
 }

--- a/services/tsunami/src/config/env.ts
+++ b/services/tsunami/src/config/env.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+import type { SiloBinding } from '@dome/silo/client';
+
+export const TsunamiEnvSchema = z.object({
+  VERSION: z.string(),
+  ENVIRONMENT: z.string(),
+  LOG_LEVEL: z.string(),
+  GITHUB_TOKEN: z.string(),
+  TOKEN_ENCRYPTION_KEY: z.string(),
+  NOTION_CLIENT_ID: z.string().optional(),
+  NOTION_CLIENT_SECRET: z.string().optional(),
+  NOTION_REDIRECT_URI: z.string().optional(),
+  RESOURCE_OBJECT: z.any(),
+  SYNC_PLAN: z.any(),
+  SILO: z.any(),
+  SILO_INGEST_QUEUE: z.any(),
+});
+
+export type ServiceEnv = z.infer<typeof TsunamiEnvSchema> & { SILO: SiloBinding };

--- a/services/tsunami/src/providers/github.ts
+++ b/services/tsunami/src/providers/github.ts
@@ -14,7 +14,7 @@ import {
 } from '../services/metadataHeaderService';
 import { IgnoreFileService } from '../services/ignoreFileService';
 import { BaseProvider } from './base';
-import type { ServiceEnv } from '../resourceObject';
+import type { ServiceEnv } from '../config/env';
 
 /* ─── constants ────────────────────────────────────────────────────────── */
 
@@ -64,7 +64,7 @@ export class GithubProvider extends BaseProvider implements Provider {
 
   constructor(env: ServiceEnv) {
     super();
-    const token = (env as any).GITHUB_TOKEN ?? '';
+    const token = env.GITHUB_TOKEN ?? '';
     this.headers = {
       Accept: 'application/vnd.github.v3+json',
       'X-GitHub-Api-Version': '2022-11-28',

--- a/services/tsunami/src/providers/notion/auth.ts
+++ b/services/tsunami/src/providers/notion/auth.ts
@@ -8,7 +8,7 @@ import { getLogger, metrics, trackedFetch, getRequestId } from '@dome/common';
 import { ServiceError } from '@dome/common/src/errors';
 import { TokenService, OAuthTokenRecord } from '../../services/tokenService'; // Corrected path
 import type { NotionOAuthDetails } from '../../client/types'; // Corrected path
-import type { ServiceEnv } from '../../resourceObject';
+import type { ServiceEnv } from '../../config/env';
 
 /**
  * Notion OAuth Token Response
@@ -43,12 +43,12 @@ export class NotionAuthManager {
   private tokenService: TokenService;
 
   constructor(env: ServiceEnv) {
-    this.clientId = (env as any).NOTION_CLIENT_ID || '';
-    this.clientSecret = (env as any).NOTION_CLIENT_SECRET || '';
-    this.redirectUri = (env as any).NOTION_REDIRECT_URI || '';
+    this.clientId = env.NOTION_CLIENT_ID ?? '';
+    this.clientSecret = env.NOTION_CLIENT_SECRET ?? '';
+    this.redirectUri = env.NOTION_REDIRECT_URI ?? '';
     this.tokenService = new TokenService(
       env.SYNC_PLAN,
-      (env as any).TOKEN_ENCRYPTION_KEY || '',
+      env.TOKEN_ENCRYPTION_KEY,
     );
 
     this.log.info(

--- a/services/tsunami/src/providers/notion/index.ts
+++ b/services/tsunami/src/providers/notion/index.ts
@@ -18,7 +18,7 @@ import { injectMetadataHeader } from '../../services/metadataHeaderService';
 import { BaseProvider } from '../base';
 import { NotionClient } from './client';
 import { NotionAuthManager } from './auth';
-import type { ServiceEnv } from '../../resourceObject';
+import type { ServiceEnv } from '../../config/env';
 
 /**
  * Notion Provider implementation

--- a/services/tsunami/src/providers/website.ts
+++ b/services/tsunami/src/providers/website.ts
@@ -8,7 +8,7 @@ import { SiloSimplePutInput, ContentCategory, MimeType } from '@dome/common';
 import { Provider, PullOpts, PullResult } from '.';
 import { logError, metrics } from '@dome/common';
 import { BaseProvider } from './base';
-import type { ServiceEnv } from '../resourceObject';
+import type { ServiceEnv } from '../config/env';
 import { RobotsChecker } from './website/robotsChecker';
 import { WebsiteCrawler } from './website/websiteCrawler';
 import { ContentExtractor } from './website/contentExtractor';

--- a/services/tsunami/src/resourceObject.ts
+++ b/services/tsunami/src/resourceObject.ts
@@ -2,10 +2,7 @@ import { DurableObject } from 'cloudflare:workers';
 import { getLogger, logError, metrics } from '@dome/common';
 import { SiloClient, SiloBinding } from '@dome/silo/client';
 import { IngestQueue } from '@dome/silo/queues';
-
-export interface ServiceEnv extends Omit<Cloudflare.Env, 'SILO'> {
-  SILO: SiloBinding;
-}
+import type { ServiceEnv } from './config/env';
 import {
   ProviderType,
   GithubProvider,

--- a/services/tsunami/src/services/syncPlanService.ts
+++ b/services/tsunami/src/services/syncPlanService.ts
@@ -1,6 +1,6 @@
 import { ulid } from 'ulid';
 import { getLogger, logError, metrics, trackOperation, getRequestId } from '@dome/common';
-import type { ServiceEnv } from '../resourceObject';
+import type { ServiceEnv } from '../config/env';
 import {
   NotFoundError,
   ConflictError,


### PR DESCRIPTION
## Summary
- add `loadEnv` helper in common package
- create env schemas for Auth, Tsunami and Silo services
- use `loadEnv` in service constructors
- remove manual env variable checks and splits
- document env validation pattern

## Testing
- `just build-no-install`
- `just lint`
- `just test`
