### PR TITLE
Implement NotionService logic and tests

### DIFF
--- a/services/dome-api/src/services/notionService.ts
+++ b/services/dome-api/src/services/notionService.ts
@@ -1,72 +1,113 @@
 import { getLogger } from '@dome/common';
 import type { Bindings } from '../types';
+import { TsunamiClient } from '@dome/tsunami/client';
 
 const logger = getLogger().child({ component: 'NotionService' });
 
 export class NotionService {
   private env: Bindings;
+  private tsunami: TsunamiClient;
 
   constructor(env: Bindings) {
     this.env = env;
+    this.tsunami = new TsunamiClient(env.TSUNAMI);
     logger.info('NotionService initialized');
   }
 
-  // Placeholder methods - these would interact with Notion's API
-  // and potentially a Notion client if one exists (e.g., this.env.NOTION_CLIENT)
+  private parseCadence(cadence?: string): number {
+    if (!cadence) return 3600;
+    const match = /PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?/.exec(cadence);
+    if (!match) return 3600;
+    const [, h, m, s] = match;
+    return (parseInt(h || '0') * 3600) + (parseInt(m || '0') * 60) + parseInt(s || '0');
+  }
 
-  async registerWorkspace(userId: string | undefined, data: any): Promise<any> {
-    logger.info({ userId, data }, 'NotionService.registerWorkspace called (placeholder)');
-    // TODO: Implement actual logic
-    return { id: 'mock_notion_ws_123', name: data.workspaceName || 'Mock Workspace' };
+  async registerWorkspace(
+    userId: string | undefined,
+    data: { workspaceId: string; cadence?: string },
+  ): Promise<{ id: string; resourceId: string; wasInitialised: boolean }> {
+    logger.info({ userId, data }, 'Registering Notion workspace');
+    const cadenceSecs = this.parseCadence(data.cadence);
+    return this.tsunami.registerNotionWorkspace(data.workspaceId, userId, cadenceSecs);
   }
 
   async getWorkspaceHistory(userId: string | undefined, workspaceId: string): Promise<any[]> {
-    logger.info({ userId, workspaceId }, 'NotionService.getWorkspaceHistory called (placeholder)');
-    // TODO: Implement actual logic
-    return [
-      {
-        id: 'mock_sync_hist_notion_1',
-        timestamp: new Date().toISOString(),
-        status: 'PENDING',
-        details: 'Placeholder sync',
-      },
-    ];
+    logger.info({ userId, workspaceId }, 'Fetching Notion workspace history');
+    const result = await this.tsunami.getNotionWorkspaceHistory(workspaceId, 10);
+    return result.history;
   }
 
   async triggerSync(userId: string | undefined, workspaceId: string): Promise<void> {
-    logger.info({ userId, workspaceId }, 'NotionService.triggerSync called (placeholder)');
-    // TODO: Implement actual logic
+    logger.info({ userId, workspaceId }, 'Triggering Notion workspace sync');
+    try {
+      await this.tsunami.initializeResource(
+        { resourceId: workspaceId, providerType: 'notion', userId },
+        0,
+      );
+    } catch (err) {
+      logger.error({ err }, 'Failed to trigger sync');
+      throw err;
+    }
   }
 
-  async configureOAuth(data: any): Promise<void> {
-    logger.info({ data }, 'NotionService.configureOAuth called (placeholder)');
-    // TODO: Implement actual logic for storing client_id/secret if needed server-side
+  async configureOAuth(data: { clientId: string; clientSecret: string; redirectUri: string }): Promise<void> {
+    logger.info('Configuring Notion OAuth');
+    this.env.NOTION_CLIENT_ID = data.clientId;
+    this.env.NOTION_CLIENT_SECRET = data.clientSecret;
+    this.env.NOTION_REDIRECT_URI = data.redirectUri;
   }
 
-  async getOAuthUrl(userId?: string): Promise<string> {
-    logger.info({ userId }, 'NotionService.getOAuthUrl called (placeholder)');
-    // TODO: Construct the actual Notion OAuth URL
-    // This would typically use a configured client_id and redirect_uri
-    const clientId = this.env.NOTION_CLIENT_ID || 'YOUR_NOTION_CLIENT_ID';
-    const redirectUri = this.env.NOTION_REDIRECT_URI || 'YOUR_NOTION_REDIRECT_URI';
-    const scope = 'read_content'; // Example scope
-    return `https://api.notion.com/v1/oauth/authorize?client_id=${clientId}&redirect_uri=${encodeURIComponent(
-      redirectUri,
-    )}&response_type=code&owner=user&scope=${scope}`;
+  async getOAuthUrl(state?: string): Promise<string> {
+    const clientId = this.env.NOTION_CLIENT_ID || '';
+    const redirectUri = this.env.NOTION_REDIRECT_URI || '';
+    const params = new URLSearchParams({
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      response_type: 'code',
+      owner: 'user',
+    });
+    if (state) params.set('state', state);
+    return `https://api.notion.com/v1/oauth/authorize?${params.toString()}`;
   }
 
   async storeIntegration(
     userId: string | undefined,
     authCode: string,
     state?: string,
-  ): Promise<any> {
-    logger.info({ userId, authCode, state }, 'NotionService.storeIntegration called (placeholder)');
-    // TODO: Exchange authCode for access token, store it, and associate with user/workspace
-    return {
-      success: true,
-      workspaceId: 'mock_notion_ws_123',
-      message: 'Integration stored successfully.',
-    };
+  ): Promise<{ success: boolean; workspaceId: string; message: string }> {
+    if (!userId) throw new Error('userId is required');
+
+    const clientId = this.env.NOTION_CLIENT_ID ?? '';
+    const clientSecret = this.env.NOTION_CLIENT_SECRET ?? '';
+    const redirectUri = this.env.NOTION_REDIRECT_URI ?? '';
+
+    const resp = await fetch('https://api.notion.com/v1/oauth/token', {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${btoa(`${clientId}:${clientSecret}`)}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ grant_type: 'authorization_code', code: authCode, redirect_uri: redirectUri }),
+    });
+
+    if (!resp.ok) {
+      throw new Error(`Token exchange failed: ${resp.status}`);
+    }
+
+    const tokenData: any = await resp.json();
+
+    const result = await this.tsunami.storeNotionOAuthDetails({
+      userId,
+      accessToken: tokenData.access_token,
+      workspaceId: tokenData.workspace_id,
+      workspaceName: tokenData.workspace_name,
+      workspaceIcon: tokenData.workspace_icon,
+      botId: tokenData.bot_id,
+      owner: tokenData.owner,
+      duplicatedTemplateId: tokenData.duplicated_template_id,
+    });
+
+    return { success: result.success, workspaceId: result.workspaceId, message: 'Integration stored successfully.' };
   }
 }
 

--- a/services/dome-api/tests/notionService.test.ts
+++ b/services/dome-api/tests/notionService.test.ts
@@ -1,0 +1,118 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Bindings } from '../src/types';
+
+vi.mock('@dome/common', () => ({
+  getLogger: () => ({ info: vi.fn(), error: vi.fn(), debug: vi.fn(), warn: vi.fn(), child: vi.fn().mockReturnThis() }),
+}));
+
+vi.mock('@dome/tsunami/client', () => {
+  return {
+    TsunamiClient: vi.fn().mockImplementation(() => ({
+      registerNotionWorkspace: vi.fn(),
+      getNotionWorkspaceHistory: vi.fn(),
+      initializeResource: vi.fn(),
+      storeNotionOAuthDetails: vi.fn(),
+    })),
+  };
+});
+
+let NotionService: typeof import('../src/services/notionService').NotionService;
+let TsunamiClient: any;
+
+beforeAll(async () => {
+  const mod = await import('../src/services/notionService');
+  NotionService = mod.NotionService;
+  TsunamiClient = (await import('@dome/tsunami/client')).TsunamiClient;
+});
+
+const createEnv = (): Bindings => ({
+  TSUNAMI: {} as any,
+  D1_DATABASE: {} as any,
+  VECTORIZE: {} as any,
+  RAW: {} as any,
+  EVENTS: {} as any,
+  SILO_INGEST_QUEUE: {} as any,
+  SILO: {} as any,
+  CHAT: {} as any,
+  AI_PROCESSOR: {} as any,
+  NOTION_CLIENT_ID: 'id',
+  NOTION_CLIENT_SECRET: 'secret',
+  NOTION_REDIRECT_URI: 'https://cb',
+} as any);
+
+describe('NotionService', () => {
+  let env: Bindings;
+  let service: any;
+  let client: any;
+
+  beforeEach(() => {
+    env = createEnv();
+    service = new NotionService(env);
+    client = (TsunamiClient as any).mock.results.at(-1).value;
+  });
+
+  it('registerWorkspace forwards to tsunami client', async () => {
+    client.registerNotionWorkspace.mockResolvedValue({ id: '1', resourceId: 'ws', wasInitialised: true });
+    const res = await service.registerWorkspace('u1', { workspaceId: 'ws', cadence: 'PT1H' });
+    expect(client.registerNotionWorkspace).toHaveBeenCalledWith('ws', 'u1', 3600);
+    expect(res).toEqual({ id: '1', resourceId: 'ws', wasInitialised: true });
+  });
+
+  it('getWorkspaceHistory returns history', async () => {
+    client.getNotionWorkspaceHistory.mockResolvedValue({ workspaceId: 'ws', resourceId: 'ws', history: [{ id: 1 }] });
+    const res = await service.getWorkspaceHistory('u1', 'ws');
+    expect(client.getNotionWorkspaceHistory).toHaveBeenCalledWith('ws', 10);
+    expect(res).toEqual([{ id: 1 }]);
+  });
+
+  it('triggerSync calls initializeResource', async () => {
+    client.initializeResource.mockResolvedValue(true);
+    await service.triggerSync('u1', 'ws');
+    expect(client.initializeResource).toHaveBeenCalledWith({ resourceId: 'ws', providerType: 'notion', userId: 'u1' }, 0);
+  });
+
+  it('configureOAuth stores values in env', async () => {
+    await service.configureOAuth({ clientId: 'n', clientSecret: 's', redirectUri: 'https://x' });
+    expect(env.NOTION_CLIENT_ID).toBe('n');
+    expect(env.NOTION_CLIENT_SECRET).toBe('s');
+    expect(env.NOTION_REDIRECT_URI).toBe('https://x');
+  });
+
+  it('getOAuthUrl constructs url', async () => {
+    const url = await service.getOAuthUrl('state');
+    expect(url).toContain('client_id=id');
+    expect(url).toContain(encodeURIComponent('https://cb'));
+    expect(url).toContain('state=state');
+  });
+
+  it('storeIntegration exchanges code and stores via tsunami', async () => {
+    global.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({
+        access_token: 'tok',
+        workspace_id: 'ws',
+        workspace_name: 'name',
+        workspace_icon: 'icon',
+        bot_id: 'bot',
+        owner: {},
+      }),
+    }) as any;
+
+    client.storeNotionOAuthDetails.mockResolvedValue({ success: true, workspaceId: 'ws' });
+
+    const res = await service.storeIntegration('u1', 'code');
+
+    expect(fetch).toHaveBeenCalled();
+    expect(client.storeNotionOAuthDetails).toHaveBeenCalledWith({
+      userId: 'u1',
+      accessToken: 'tok',
+      workspaceId: 'ws',
+      workspaceName: 'name',
+      workspaceIcon: 'icon',
+      botId: 'bot',
+      owner: {},
+      duplicatedTemplateId: undefined,
+    });
+    expect(res).toEqual({ success: true, workspaceId: 'ws', message: 'Integration stored successfully.' });
+  });
+});


### PR DESCRIPTION
## Summary
- implement real logic for NotionService
- add accompanying unit tests

## Testing
- `just build-no-install`
- `just lint`
- `just test`
