### PR TITLE
Improve chat mobile layout

### DIFF
--- a/ui/src/components/chat/ChatInput.tsx
+++ b/ui/src/components/chat/ChatInput.tsx
@@ -52,7 +52,7 @@ export const ChatInput: React.FC = () => {
     <div className="sticky bottom-0 border-t bg-background shadow-t-md">
       <form
         onSubmit={handleSubmit}
-        className="flex w-full items-center gap-2 p-3 md:p-4"
+        className="flex w-full items-center gap-2 p-2 sm:p-3 md:p-4"
       >
         <Input
           type="text"

--- a/ui/src/components/chat/ChatMessagesList.tsx
+++ b/ui/src/components/chat/ChatMessagesList.tsx
@@ -88,7 +88,7 @@ export const ChatMessagesList: React.FC = () => {
 
   return (
     <ScrollArea className="flex-1" ref={scrollAreaRootRef}>
-      <div className="space-y-6 p-4 md:p-6">
+      <div className="space-y-6 p-0 sm:p-4 md:p-6">
         {sortedMessages.map((msg: ParsedMessage) => { // Use sortedMessages
           switch (msg.sender) {
             case 'user':

--- a/ui/src/components/layout/LayoutWithSidebar.tsx
+++ b/ui/src/components/layout/LayoutWithSidebar.tsx
@@ -2,6 +2,7 @@
 
 import React from 'react';
 import { usePathname } from 'next/navigation';
+import { cn } from '@/lib/utils';
 import { Sidebar } from '@/components/sidebar/Sidebar';
 import { Header } from '@/components/layout/Header';
 
@@ -32,6 +33,7 @@ export function LayoutWithSidebar({ children }: LayoutWithSidebarProps) {
   const pathname = usePathname();
   const isAuthRoute = AUTH_ROUTES.some((route) => pathname.startsWith(route));
   const isLandingPage = pathname === '/';
+  const isChatPage = pathname.startsWith('/chat');
 
   if (isAuthRoute || isLandingPage) {
     return <>{children}</>;
@@ -49,7 +51,7 @@ export function LayoutWithSidebar({ children }: LayoutWithSidebarProps) {
         {/* Main Content Area */}
         {/* Removed sticky header from here as it's now a global Header component */}
         <main className="flex-1 overflow-y-auto bg-background">
-          <div className="p-4 sm:p-6 lg:p-8">
+          <div className={cn('p-4 sm:p-6 lg:p-8', isChatPage && 'p-0') }>
             {children}
           </div>
         </main>


### PR DESCRIPTION
## Summary
- make chat messages list flush to screen edges on mobile
- adjust chat input padding for small screens
- allow zero padding on /chat page via LayoutWithSidebar

## Testing
- `just build-no-install`
- `just lint`
- `just test`
