### PR TITLE
Fix chat input cursor

### DIFF
--- a/ui/src/app/globals.css
+++ b/ui/src/app/globals.css
@@ -152,10 +152,6 @@ h4 { @apply text-xl font-semibold tracking-tight; }
     vertical-align: bottom;
     animation: block-blink 1s steps(1) infinite;
   }
-  .minimal-input[data-placeholder]:empty::before {
-    content: attr(data-placeholder);
-    @apply text-muted-foreground;
-  }
   @keyframes block-blink {
     0%,50% { opacity: 1; }
     50.01%,100% { opacity: 0; }

--- a/ui/src/components/chat/ChatInput.tsx
+++ b/ui/src/components/chat/ChatInput.tsx
@@ -58,7 +58,6 @@ export const ChatInput: React.FC = () => {
         ref={inputRef}
         contentEditable
         role="textbox"
-        data-placeholder="Type a message"
         onInput={(e) => setInputValue(e.currentTarget.textContent || '')}
         onKeyDown={handleKeyDown}
         className="minimal-input w-full"


### PR DESCRIPTION
## Summary
- remove the placeholder text from chat input so the cursor starts at the beginning
- drop unused CSS placeholder rule

## Testing
- `just build-no-install`
- `just lint`
- `just test`
