### PR TITLE
Add ping rpc to constellation

### DIFF
--- a/services/constellation/src/handlers/rpc.ts
+++ b/services/constellation/src/handlers/rpc.ts
@@ -269,3 +269,20 @@ export async function stats(this: any) {
     },
   );
 }
+
+export async function ping(this: any) {
+  const requestId = crypto.randomUUID();
+  return runWithLog(
+    {
+      service: 'constellation',
+      op: 'ping',
+      requestId,
+      ...this.env,
+    },
+    async () => {
+      metrics.counter('rpc.ping.requests', 1);
+      getLogger().debug({ requestId, operation: 'ping' }, 'Ping request received');
+      return { status: 'ok' };
+    },
+  );
+}

--- a/services/constellation/src/index.ts
+++ b/services/constellation/src/index.ts
@@ -456,5 +456,15 @@ export default class Constellation extends BaseWorker<ServiceEnv, ReturnType<typ
   public async stats() {
     return rpcHandlers.stats.call(this);
   }
+
+  /* ---------------------------- rpc: ping ------------------------------ */
+
+  /**
+   * Simple health check method
+   * @returns A status object indicating service is running
+   */
+  public async ping() {
+    return rpcHandlers.ping.call(this);
+  }
 }
 export { sendToDeadLetter };

--- a/services/constellation/tests/ping.test.ts
+++ b/services/constellation/tests/ping.test.ts
@@ -1,0 +1,9 @@
+import { describe, it, expect } from 'vitest';
+import { ping } from '../src/handlers/rpc';
+
+describe('ping', () => {
+  it('returns ok status', async () => {
+    const res = await ping.call({ env: {} });
+    expect(res).toEqual({ status: 'ok' });
+  });
+});


### PR DESCRIPTION
## Summary
- implement a new `ping` rpc handler for Constellation
- expose `ping` via the worker class
- test ping

## Testing
- `just build-no-install`
- `just lint`
- `just test`
