### PR TITLE
Fix deploy matrix parsing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,20 +26,21 @@ jobs:
           files="${{ steps.filter.outputs.services_files }}"
           if [[ -z "$files" ]]; then
             echo "any=false" >>"$GITHUB_OUTPUT"
-            echo "services=" >>"$GITHUB_OUTPUT"
+            echo "services=[]" >>"$GITHUB_OUTPUT"
             exit 0
           fi
-          services=$(echo "$files" | tr ',' '\n' | cut -d/ -f2 | sort -u | tr '\n' ' ')
-          echo "Changed services: $services"
+          services=$(echo "$files" | tr ',' '\n' | cut -d/ -f2 | sort -u)
+          echo "Changed services: $(echo "$services" | tr '\n' ' ')"
+          services_json=$(printf '%s\n' $services | jq -R -s -c 'split("\n")[:-1]')
           echo "any=true" >>"$GITHUB_OUTPUT"
-          echo "services=$services" >>"$GITHUB_OUTPUT"
+          echo "services=$services_json" >>"$GITHUB_OUTPUT"
 
   deploy:
     needs: detect
     if: needs.detect.outputs.any == 'true'
     strategy:
       matrix:
-        service: ${{ fromJson(toJson(split(needs.detect.outputs.services, ' '))) }}
+        service: ${{ fromJson(needs.detect.outputs.services) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- set deploy services output to a JSON array
- parse this array for the matrix in deploy job

## Testing
- `just build-no-install`
- `just lint`
- `just test`
