### PR TITLE
Fix deployment workflow env and Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
 
       - name: Setup PNPM
         uses: pnpm/action-setup@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,10 +46,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
-        with: {node-version: 18}
+        with: {node-version: 20}
       - run: npm install -g wrangler@latest
       - name: Deploy ${{ matrix.service }}
         working-directory: services/${{ matrix.service }}
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-        run: wrangler deploy --env production
+        run: wrangler deploy

--- a/services/ai-processor/wrangler.toml
+++ b/services/ai-processor/wrangler.toml
@@ -65,11 +65,11 @@ LOG_LEVEL = "info"
 ENVIRONMENT = "staging"
 
 # Production environment
-[env.prod]
+[env.production]
 name = "ai-processor"
-[env.prod.vars]
+[env.production.vars]
 LOG_LEVEL = "info"
-ENVIRONMENT = "prod"
+ENVIRONMENT = "production"
 
 [observability]
 enabled = true

--- a/services/todos/wrangler.toml
+++ b/services/todos/wrangler.toml
@@ -38,11 +38,11 @@ LOG_LEVEL = "info"
 ENVIRONMENT = "staging"
 
 # Production environment
-[env.prod]
+[env.production]
 workers_dev = false
-[env.prod.vars]
+[env.production.vars]
 LOG_LEVEL = "info"
-ENVIRONMENT = "prod"
+ENVIRONMENT = "production"
 
 # Miniflare configuration for local development
 [miniflare]


### PR DESCRIPTION
## Summary
- update Node.js to v20 in CI and deployment workflows
- remove env detection from deployment step
- standardize Cloudflare production env names

## Testing
- `just lint`
- `just build-no-install`
- `just test`
