### PR TITLE
Fix usage of Node crypto

### DIFF
--- a/packages/common/src/middleware/requestContext.ts
+++ b/packages/common/src/middleware/requestContext.ts
@@ -1,5 +1,4 @@
 import type { Context, Next } from 'hono';
-import crypto from 'node:crypto';
 
 /**
  * Middleware factory for creating request context middleware

--- a/packages/common/src/types/events.ts
+++ b/packages/common/src/types/events.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import crypto from 'node:crypto';
 
 /**
  * Base event schema that all events must extend

--- a/packages/common/tests/requestContext.test.ts
+++ b/packages/common/tests/requestContext.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi } from 'vitest';
-import crypto from 'node:crypto';
 import { createRequestContextMiddleware } from '../src/middleware/requestContext';
 
 describe('createRequestContextMiddleware', () => {
@@ -20,7 +19,7 @@ describe('createRequestContextMiddleware', () => {
 
   it('generates id when none provided', async () => {
     const uuid = 'generated';
-    vi.spyOn(crypto, 'randomUUID').mockReturnValue(uuid as any);
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(uuid as any);
     const c: any = {
       req: { header: vi.fn().mockReturnValue(undefined) },
       get: vi.fn().mockReturnValue(undefined),


### PR DESCRIPTION
## Summary
- remove `node:crypto` imports from common package
- update tests to spy on global `crypto`

## Testing
- `just build-no-install`
- `just lint`
- `just test`
