### PR TITLE
Fix service list parsing in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,7 @@ jobs:
             echo "services=[]" >>"$GITHUB_OUTPUT"
             exit 0
           fi
-          services=$(echo "$files" | cut -d/ -f2 | sort -u)
+          services=$(printf '%s\n' $files | cut -d/ -f2 | sort -u)
           echo "Changed services: $(echo "$services" | tr '\n' ' ')"
           services_json=$(printf '%s\n' $services | jq -R -s -c 'split("\n")[:-1]')
           echo "any=true" >>"$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- ensure changed services are parsed correctly in the deploy workflow

## Testing
- `just build-no-install`
- `just lint`
- `just test`
