### PR TITLE
Fix Notion provider import paths

### DIFF
--- a/services/tsunami/src/providers/notion/auth.ts
+++ b/services/tsunami/src/providers/notion/auth.ts
@@ -5,7 +5,7 @@
  * including token exchange and secure storage.
  */
 import { getLogger, metrics, trackedFetch, getRequestId } from '@dome/common';
-import { ServiceError } from '@dome/common/src/errors';
+import { ServiceError } from '@dome/common/errors';
 import { TokenService, OAuthTokenRecord } from '../../services/tokenService'; // Corrected path
 import type { NotionOAuthDetails } from '../../client/types'; // Corrected path
 import type { ServiceEnv } from '../../config/env';

--- a/services/tsunami/src/providers/notion/client.ts
+++ b/services/tsunami/src/providers/notion/client.ts
@@ -5,7 +5,7 @@
  * rate limiting, and error handling.
  */
 import { getLogger, metrics, trackedFetch, getRequestId } from '@dome/common';
-import { ServiceError } from '@dome/common/src/errors';
+import { ServiceError } from '@dome/common/errors';
 import { NotionAuthManager } from './auth';
 
 /* ─── Constants ───────────────────────────────────────────────────────────── */

--- a/services/tsunami/src/providers/notion/utils.ts
+++ b/services/tsunami/src/providers/notion/utils.ts
@@ -5,7 +5,7 @@
  * data structures into the standard format expected by tsunami.
  */
 import { getLogger, getRequestId } from '@dome/common';
-import { ValidationError } from '@dome/common/src/errors';
+import { ValidationError } from '@dome/common/errors';
 import { assertValid } from '../../utils/errors';
 import { DomeMetadata } from '../../types/metadata';
 import { ContentCategory, MimeType } from '@dome/common';


### PR DESCRIPTION
## Summary
- fix imports for `ServiceError` and `ValidationError` to use the public `@dome/common/errors` entrypoint

## Testing
- `just build-no-install`
- `just lint`
- `just test`
