### PR TITLE
Fix sidebar search result behavior

### DIFF
--- a/ui/src/components/search/SearchResultCard.tsx
+++ b/ui/src/components/search/SearchResultCard.tsx
@@ -12,6 +12,8 @@ import { Badge } from '@/components/ui/badge';
 interface SearchResultCardProps {
   /** The search result item data to display. */
   item: SearchResultItem;
+  /** Callback when the card is selected. */
+  onSelect?: () => void;
 }
 
 /**
@@ -22,7 +24,7 @@ interface SearchResultCardProps {
  * @param props - The props for the component.
  * @returns A React functional component representing a search result card.
  */
-export function SearchResultCard({ item }: SearchResultCardProps) {
+export function SearchResultCard({ item, onSelect }: SearchResultCardProps) {
   const router = useRouter();
 
   /**
@@ -44,6 +46,7 @@ export function SearchResultCard({ item }: SearchResultCardProps) {
     // Ensure item.id is present; otherwise, this navigation will fail or be incorrect.
     // Consider adding a check or fallback if item.id could be missing.
     router.push(`/search/view/${item.id}?${queryParams.toString()}`);
+    onSelect?.();
   };
 
   return (

--- a/ui/src/components/search/SearchResultsList.tsx
+++ b/ui/src/components/search/SearchResultsList.tsx
@@ -8,6 +8,8 @@ import { SearchResultCard } from './SearchResultCard';
 interface SearchResultsListProps {
   /** An array of search result items to display. */
   results: SearchResultItem[];
+  /** Callback when a result is selected. */
+  onSelect?: () => void;
 }
 
 /**
@@ -18,7 +20,7 @@ interface SearchResultsListProps {
  * @param props - The props for the component.
  * @returns A React functional component displaying a list of search results, or null if results are empty.
  */
-export function SearchResultsList({ results }: SearchResultsListProps) {
+export function SearchResultsList({ results, onSelect }: SearchResultsListProps) {
   // The parent component (e.g., a page or a more complex search UI container)
   // is responsible for showing "no results" messages or loading indicators.
   // This component's sole responsibility is to render the list if results exist.
@@ -29,7 +31,7 @@ export function SearchResultsList({ results }: SearchResultsListProps) {
   return (
     <div className="space-y-3"> {/* Reduced spacing for a tighter list in the sidebar */}
       {results.map((item) => (
-        <SearchResultCard key={item.id} item={item} />
+        <SearchResultCard key={item.id} item={item} onSelect={onSelect} />
       ))}
     </div>
   );

--- a/ui/src/components/sidebar/MobileSidebar.tsx
+++ b/ui/src/components/sidebar/MobileSidebar.tsx
@@ -15,8 +15,11 @@ import { Sidebar } from './Sidebar';
  * @returns A React functional component representing the mobile sidebar toggle and sheet.
  */
 export function MobileSidebar() {
+  const [open, setOpen] = React.useState(false);
+  const handleResultClick = React.useCallback(() => setOpen(false), []);
+
   return (
-    <Sheet>
+    <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger asChild>
         <Button variant="ghost" size="icon" className="md:hidden">
           <Menu />
@@ -24,7 +27,7 @@ export function MobileSidebar() {
         </Button>
       </SheetTrigger>
       <SheetContent side="left" className="p-0 w-72"> {/* Removed pt-6, Sidebar will handle its padding. Explicitly set width. */}
-        <Sidebar />
+        <Sidebar onResultClick={handleResultClick} />
       </SheetContent>
     </Sheet>
   );

--- a/ui/src/components/sidebar/Sidebar.tsx
+++ b/ui/src/components/sidebar/Sidebar.tsx
@@ -14,6 +14,8 @@ import { cn } from '@/lib/utils';
 interface SidebarProps {
   /** Optional additional CSS class names for the sidebar container. */
   className?: string;
+  /** Callback when a search result is selected. */
+  onResultClick?: () => void;
 }
 
 /**
@@ -25,7 +27,7 @@ interface SidebarProps {
  * @param props.className - Optional additional CSS class names for the sidebar container.
  * @returns A React functional component representing the application sidebar.
  */
-export function Sidebar({ className }: SidebarProps) {
+export function Sidebar({ className, onResultClick }: SidebarProps) {
   const [searchResults, setSearchResults] = useState<SearchResultItem[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -94,7 +96,7 @@ export function Sidebar({ className }: SidebarProps) {
         )}
         {/* Only render SearchResultsList if there are actual results and not in a loading/error state that implies no results yet */}
         {!isLoading && !error && searchResults.length > 0 && (
-          <SearchResultsList results={searchResults} />
+          <SearchResultsList results={searchResults} onSelect={onResultClick} />
         )}
       </div>
     </aside>

--- a/ui/src/components/ui/sheet.tsx
+++ b/ui/src/components/ui/sheet.tsx
@@ -100,7 +100,7 @@ const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
 >(({ side = "right", className, children, ...props }, ref) => (
-  <SheetPortal>
+  <SheetPortal forceMount>
     <SheetOverlay />
     <SheetPrimitive.Content
       ref={ref}


### PR DESCRIPTION
## Summary
- close mobile sidebar when selecting a search result
- keep sidebar contents mounted when closed so results persist

## Testing
- `just build-no-install` *(fails: `just` not found)*
- `just lint` *(fails: `just` not found)*
- `just test` *(fails: `just` not found)*