### PR TITLE
Fix mobile search sidebar and back button

### DIFF
--- a/ui/src/app/search/view/[id]/page.tsx
+++ b/ui/src/app/search/view/[id]/page.tsx
@@ -12,18 +12,25 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 import { notesApi, Note } from '../../../../lib/api'; // Adjusted path
 
 interface SearchResultViewPageProps {
-  params: Promise<{ id: string }>;
-  searchParams?: Promise<Record<string, string | string[] | undefined>>;
+  params: { id: string };
+  searchParams?: Record<string, string | string[] | undefined>;
 }
 
-// Using any as a temporary workaround for the persistent PageProps constraint issue
 const SearchResultViewPage: React.FC<SearchResultViewPageProps> = ({ params }) => {
   const router = useRouter();
   const [note, setNote] = useState<Note | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const { id: noteId } = React.use(params);
+  const { id: noteId } = params;
+
+  const handleBack = () => {
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      router.back();
+    } else {
+      router.push('/search');
+    }
+  };
 
   useEffect(() => {
     if (noteId) {
@@ -66,7 +73,7 @@ const SearchResultViewPage: React.FC<SearchResultViewPageProps> = ({ params }) =
   if (error || !note) {
     return (
       <div className="container mx-auto p-4">
-        <Button onClick={() => router.back()} variant="outline" className="mb-4">
+        <Button onClick={handleBack} variant="outline" className="mb-4">
           <ArrowLeftIcon className="mr-2 h-4 w-4" /> Back to Search
         </Button>
         <Card>
@@ -103,7 +110,7 @@ const SearchResultViewPage: React.FC<SearchResultViewPageProps> = ({ params }) =
 
   return (
     <div className="container mx-auto p-4 md:p-6 lg:p-8">
-      <Button onClick={() => router.back()} variant="outline" className="mb-6 inline-flex items-center">
+      <Button onClick={handleBack} variant="outline" className="mb-6 inline-flex items-center">
         <ArrowLeftIcon className="mr-2 h-5 w-5" />
         Back to Search Results
       </Button>

--- a/ui/src/components/sidebar/MobileSidebar.tsx
+++ b/ui/src/components/sidebar/MobileSidebar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React from 'react';
+import { usePathname } from 'next/navigation';
 import { Menu } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from '@/components/ui/sheet';
@@ -16,7 +17,13 @@ import { Sidebar } from './Sidebar';
  */
 export function MobileSidebar() {
   const [open, setOpen] = React.useState(false);
+  const pathname = usePathname();
   const handleResultClick = React.useCallback(() => setOpen(false), []);
+
+  React.useEffect(() => {
+    // Close the sidebar whenever navigation occurs
+    setOpen(false);
+  }, [pathname]);
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>


### PR DESCRIPTION
## Summary
- close the mobile search sidebar when navigating
- improve SearchResult view page back button and types

## Testing
- `just lint`
- `just build-no-install`
- `just test`
