### PR TITLE
fix page props typing

### DIFF
--- a/ui/src/app/search/view/[id]/page.tsx
+++ b/ui/src/app/search/view/[id]/page.tsx
@@ -11,12 +11,12 @@ import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle }
 // import { SearchResultItem } from '@/lib/types/search';
 import { notesApi, Note } from '../../../../lib/api'; // Adjusted path
 
-interface SearchResultViewPageProps {
+export default function SearchResultViewPage({
+  params,
+}: {
   params: { id: string };
   searchParams?: Record<string, string | string[] | undefined>;
-}
-
-const SearchResultViewPage: React.FC<SearchResultViewPageProps> = ({ params }) => {
+}) {
   const router = useRouter();
   const [note, setNote] = useState<Note | null>(null);
   const [loading, setLoading] = useState(true);
@@ -166,6 +166,4 @@ const SearchResultViewPage: React.FC<SearchResultViewPageProps> = ({ params }) =
       </Card>
     </div>
   );
-};
-
-export default SearchResultViewPage;
+}

--- a/ui/src/components/chat/ChatMessagesList.tsx
+++ b/ui/src/components/chat/ChatMessagesList.tsx
@@ -21,21 +21,25 @@ export const ChatMessagesList: React.FC = () => {
   const scrollAreaRootRef = useRef<HTMLDivElement>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  // Define the desired order for assistant message types within a single turn
-  const assistantMessageTypeOrder: Record<
-    AssistantContentMessage['type'] |
-    AssistantThinkingMessage['type'] |
-    AssistantSourcesMessage['type'] |
-    AssistantReasoningMessage['type'] |
-    AssistantErrorMessage['type'], // Only assistant-specific types that have a 'type' property
+  // Define the desired order for assistant message types within a single turn.
+  // Memoize so the object reference remains stable across renders.
+  const assistantMessageTypeOrder = useMemo(
+    () => ({
+      thinking: 1,
+      reasoning: 2,
+      sources: 3,
+      content: 4,
+      error: 5, // Assistant errors related to the turn
+    }),
+    []
+  ) as Record<
+    | AssistantContentMessage['type']
+    | AssistantThinkingMessage['type']
+    | AssistantSourcesMessage['type']
+    | AssistantReasoningMessage['type']
+    | AssistantErrorMessage['type'],
     number
-  > = {
-    thinking: 1,
-    reasoning: 2,
-    sources: 3,
-    content: 4,
-    error: 5, // Assistant errors related to the turn
-  };
+  >;
 
   const sortedMessages = useMemo(() => {
     return [...messages].sort((a, b) => {
@@ -79,7 +83,7 @@ export const ChatMessagesList: React.FC = () => {
 
       return timeDiff;
     });
-  }, [messages, assistantMessageTypeOrder]); // Add assistantMessageTypeOrder to dependencies
+  }, [messages]);
 
   useEffect(() => {
     // Scroll to the bottom when sorted messages change or loading state changes.


### PR DESCRIPTION
## Summary
- correct SearchResultViewPage typing for Next.js
- memoize assistant message type order to stabilize `useMemo`

## Testing
- `just build-no-install`
- `just lint`
- `just test`
