### PR TITLE
fix: clean up package.json organization

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,15 @@
     "test:context": "tsc && node dist/tests/run-tests.js",
     "cli:link": "npm link"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "description": "",
+  "keywords": ["ai", "mastra", "cli", "dome"],
+  "author": "marktoda",
+  "license": "MIT",
+  "description": "Dome - AI assistant powered by Mastra framework",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/marktoda/dome.git"
+  },
+  "homepage": "https://github.com/marktoda/dome#readme",
   "type": "module",
   "engines": {
     "node": ">=20.9.0"
@@ -38,8 +43,6 @@
     "@mastra/memory": "^0.11.2",
     "@mastra/pg": "^0.12.2",
     "@mastra/rag": "^1.0.2",
-    "@types/react": "^19.1.8",
-    "@types/uuid": "^10.0.0",
     "ai": "^4.3.17",
     "apache-arrow": "^18.0.0",
     "chalk": "^5.4.1",
@@ -70,6 +73,8 @@
   },
   "devDependencies": {
     "@types/node": "^24.0.13",
+    "@types/react": "^19.1.8",
+    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^7.8.0",
     "@typescript-eslint/parser": "^7.8.0",
     "eslint": "^9.3.0",


### PR DESCRIPTION
Implements the first cleanup recommendation from issue #237

## Changes
- Move @types/react and @types/uuid from dependencies to devDependencies
- Add missing package metadata: author, license (MIT), description
- Add repository and homepage fields for better npm discoverability
- Add relevant keywords for the project

Generated with [Claude Code](https://claude.ai/code)