### PR TITLE
fix: simplify build process by removing unused mastra build step

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Turn plain Markdown into a searchable, self-organising second brain – all from
 npm install
 
 # Build the CLI (needed once after each pull)
-npm run cli:build
+npm run build
 
 # Link the binary so 'dome' is available on your PATH
 npm link

--- a/package.json
+++ b/package.json
@@ -7,11 +7,10 @@
   },
   "scripts": {
     "clean": "rimraf dist",
-    "build": "npm run clean && npm run cli:build && mastra build",
+    "build": "npm run clean && npm run cli:build",
     "dev": "mastra dev",
     "cli:dev": "tsx src/cli/index.ts",
     "cli:build": "tsc -p tsconfig.json",
-    "mastra:build": "mastra build",
     "start": "mastra start",
     "lint": "eslint . --ext .ts,.tsx --max-warnings=0",
     "format": "prettier --write .",


### PR DESCRIPTION
Implements the fourth cleanup recommendation from issue #237

## Changes
- Remove 'mastra build' from the build script as it's not used
- Remove unused 'mastra:build' script alias
- Update README.md to use 'npm run build' instead of 'cli:build'

This simplifies the build process to only use TypeScript compilation as requested by @marktoda

Generated with [Claude Code](https://claude.ai/code)